### PR TITLE
fix(release): align Homebrew and Linux ARM64 metadata

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -154,7 +154,7 @@ jobs:
               "# This formula is maintained via the heycupola/wrapper release workflow.",
               "class Wrapper < Formula",
               '  desc "Securely host and attach your terminal sessions across devices"',
-              '  homepage "https://wrapper.sh"',
+              '  homepage "https://www.wrapper.sh"',
               f'  version "{os.environ["VERSION"]}"',
               '  license "MIT"',
               "",

--- a/apps/cli/tests/release-workflows.test.ts
+++ b/apps/cli/tests/release-workflows.test.ts
@@ -126,5 +126,6 @@ describe("CLI release workflows", () => {
     expect(homebrewWorkflow).toContain("checksum_digest != asset_digest");
     expect(homebrewWorkflow).toContain("SHA_LINUX_ARM64");
     expect(homebrewWorkflow).toContain("ruby -c Formula/wrapper.rb");
+    expect(homebrewWorkflow).toContain('homepage "https://www.wrapper.sh"');
   });
 });

--- a/apps/docs/introduction.mdx
+++ b/apps/docs/introduction.mdx
@@ -38,8 +38,8 @@ Checksum-verified installer:
 curl -fsSL https://wrapper.sh/install | bash
 ```
 
-Supported installer targets today: `darwin-arm64`, `darwin-x86_64`, and
-`linux-x86_64`.
+Supported installer targets today: `darwin-arm64`, `darwin-x86_64`,
+`linux-arm64`, and `linux-x86_64`.
 
 ## First session
 


### PR DESCRIPTION
## Summary
- keep future Wrapper Homebrew formulas on the canonical www domain
- document Linux ARM64 now that v0.1.0 publishes and verifies that target
- lock the canonical homepage expectation in release workflow tests

## Test plan
- [x] Validate the Homebrew workflow with actionlint
- [x] Pass release workflow tests
- [x] Pass docs formatting
- [x] Fetch the published v0.1.0 Homebrew archive successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and documentation only; no runtime, auth, or install script logic changes.
> 
> **Overview**
> Updates the **Homebrew formula** generated by the release workflow so `homepage` points at **`https://www.wrapper.sh`** instead of the bare `wrapper.sh` domain.
> 
> **Docs** now list **`linux-arm64`** alongside the existing installer platforms, matching published v0.1.0 artifacts. A **release workflow test** asserts the canonical homepage string stays in the Homebrew tap updater.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8873e86c8a8a28005cad1cb4a0ffe0f0ca56c31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->