### PR TITLE
fix(deps): keep automated updates reviewable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: "chore(deps)"
 
@@ -37,5 +41,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: "chore(actions)"

--- a/patches/extract-zip@2.0.1.patch
+++ b/patches/extract-zip@2.0.1.patch
@@ -2,8 +2,7 @@ diff --git a/index.js b/index.js
 index 00105fe..ec8f5f2 100644
 --- a/index.js
 +++ b/index.js
-@@ -126,6 +126,17 @@ class Extractor {
- 
+@@ -127,5 +127,16 @@ class Extractor {
      if (symlink) {
        const link = await getStream(readStream)
 +      const resolvedLink = path.resolve(path.dirname(dest), link)


### PR DESCRIPTION
## Summary
- ignore automatic major dependency and action upgrades
- normalize the local extract-zip security patch without trailing whitespace

## Test plan
- [x] Apply the patched dependency from a clean install
- [x] Run the extractor security regression on Bun 1.3.5 and 1.3.11
- [x] Run monorepo lint, types, tests, and audit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and patch-file formatting only; no runtime application code changes.
> 
> **Overview**
> **Dependabot** now ignores **semver-major** updates for both **Bun** dependencies and **GitHub Actions**, so weekly grouped PRs stay limited to minor/patch bumps that match the existing update groups.
> 
> The **`extract-zip@2.0.1`** patch is reformatted (hunk line numbers and trailing whitespace) without changing the symlink path-traversal guard behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 150c2fb678fc30e9c393f4e45082e9ed2e3ed8c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->