### PR TITLE
feat(web): put signed-out dashboard on the auth card

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,10 +1,10 @@
 import type { ReactNode } from "react";
 import { redirect } from "next/navigation";
+import { AuthShell } from "../../components/auth-shell";
 import { SiteHeader } from "../../components/landing-header";
 import { getAuthProviderAvailability } from "../../lib/auth-providers";
 import { getToken, isAuthenticated } from "../../lib/auth-server";
 import { getDashboardOnboardingState } from "../../lib/dashboard-server";
-import { DashboardPageHeader } from "./dashboard-page-header";
 import { DashboardSidebar } from "./dashboard-sidebar";
 import { DashboardSignIn } from "./dashboard-sign-in";
 
@@ -18,28 +18,25 @@ export default async function DashboardLayout({ children }: { children: ReactNod
     if (onboarding?.needsOnboarding) redirect("/onboarding");
   }
 
+  if (!signedIn) {
+    return (
+      <AuthShell
+        title="Sign in"
+        description="Use the provider linked to your Wrapper profile."
+        showHeaderAction={false}
+        showFooter={false}
+      >
+        <DashboardSignIn appleEnabled={providers.apple} />
+      </AuthShell>
+    );
+  }
+
   return (
     <div className="dashboardShell">
       <SiteHeader showAction={false} />
-      <main
-        id="main-content"
-        className={signedIn ? "dashboardMain" : "dashboardMain dashboardMainSignedOut"}
-        tabIndex={-1}
-      >
-        {signedIn ? <DashboardSidebar /> : null}
-        <section className="dashboardWorkspace">
-          {signedIn ? (
-            children
-          ) : (
-            <>
-              <DashboardPageHeader
-                title="Sign in"
-                description="Use the provider linked to your Wrapper profile."
-              />
-              <DashboardSignIn appleEnabled={providers.apple} />
-            </>
-          )}
-        </section>
+      <main id="main-content" className="dashboardMain" tabIndex={-1}>
+        <DashboardSidebar />
+        <section className="dashboardWorkspace">{children}</section>
       </main>
     </div>
   );

--- a/apps/web/app/surfaces.css
+++ b/apps/web/app/surfaces.css
@@ -154,10 +154,6 @@
   padding: clamp(36px, 5vw, 56px) var(--page-pad) 72px;
 }
 
-.dashboardMainSignedOut {
-  grid-template-columns: minmax(0, 1fr);
-}
-
 .dashboardSidebar {
   position: sticky;
   top: calc(var(--header-h) + 28px);
@@ -241,7 +237,6 @@
 
 .dashboardSignIn {
   display: grid;
-  max-width: 360px;
   gap: 16px;
 }
 


### PR DESCRIPTION
## Summary
- Signed-out `/dashboard` uses the shared AuthShell card instead of flush-left canvas copy.
- Login stays a single Sign in heading with stacked providers, matching authorize.

## Test plan
- [ ] Signed-out `/dashboard` shows a centered Sign in card with GitHub/Google (and Apple if enabled)
- [ ] Support link still works
- [ ] After sign-in, dashboard is still Wrapper + page title + account nav, no marketing footer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change for the unauthenticated dashboard view; auth checks and signed-in dashboard structure are unchanged.
> 
> **Overview**
> Signed-out `/dashboard` now renders the shared `AuthShell` card (header action and footer off) instead of the dashboard canvas with a flush-left `DashboardPageHeader`.
> 
> Signed-in layout is unchanged: sidebar + workspace only. Signed-out CSS (`.dashboardMainSignedOut` and the 360px sign-in max-width) is removed so providers sit in the centered auth card like authorize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fd44d00a92ab611d9a447ef6560c5613446aa9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->