### PR TITLE
feat(web): tighten the signed-out sign-in card

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -22,7 +22,8 @@ export default async function DashboardLayout({ children }: { children: ReactNod
     return (
       <AuthShell
         title="Sign in"
-        description="Use the provider linked to your Wrapper profile."
+        description="Continue with the account on your Wrapper profile."
+        size="narrow"
         showHeaderAction={false}
         showFooter={false}
       >

--- a/apps/web/app/surfaces.css
+++ b/apps/web/app/surfaces.css
@@ -237,17 +237,20 @@
 
 .dashboardSignIn {
   display: grid;
-  gap: 16px;
+  gap: 18px;
 }
 
 .dashboardSignIn .authActions {
   display: grid;
-  gap: 10px;
+  width: 100%;
+  gap: 8px;
 }
 
-.dashboardSignIn .social-btn {
+.dashboardSignIn .authActions .social-btn {
   width: 100%;
-  justify-content: center;
+  min-height: 48px;
+  justify-content: flex-start;
+  padding-inline: 16px;
 }
 
 .dashboardPanel {
@@ -676,6 +679,26 @@
   border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--color-surface-strong) 88%, transparent);
   box-shadow: var(--color-shadow);
+}
+
+.authSurfaceNarrow {
+  width: min(100%, 384px);
+  gap: 22px;
+  padding: 28px 28px 24px;
+}
+
+.authSurfaceNarrow .authPageHeader {
+  gap: 8px;
+  padding-bottom: 0;
+}
+
+.authSurfaceNarrow .authTitle {
+  font-size: clamp(1.7rem, 5vw, 2.05rem);
+}
+
+.authSurfaceNarrow .authDescription {
+  max-width: none;
+  font-size: 0.875rem;
 }
 
 .authSurfaceWide {

--- a/apps/web/components/auth-shell.tsx
+++ b/apps/web/components/auth-shell.tsx
@@ -13,18 +13,18 @@ export function AuthShell({
   title?: string;
   description?: string;
   children: ReactNode;
-  size?: "compact" | "wide";
+  size?: "narrow" | "compact" | "wide";
   showHeaderAction?: boolean;
   showFooter?: boolean;
 }) {
+  const surfaceClass =
+    size === "wide" ? "authSurfaceWide" : size === "narrow" ? "authSurfaceNarrow" : "";
+
   return (
     <div className={`authShell authShell-${size}`}>
       <SiteHeader showAction={showHeaderAction} />
       <main id="main-content" className="authMain" tabIndex={-1}>
-        <section
-          className={`authSurface ${size === "wide" ? "authSurfaceWide" : ""}`}
-          aria-labelledby="auth-page-title"
-        >
+        <section className={`authSurface ${surfaceClass}`.trim()} aria-labelledby="auth-page-title">
           {title ? (
             <header className="authPageHeader">
               <h1 id="auth-page-title" className="authTitle">


### PR DESCRIPTION
## Summary
- Give Sign in its own narrow AuthShell measure so the title, copy, and provider buttons share one column.
- Keep authorize and onboarding on the wider card.

## Test plan
- [ ] Signed-out `/dashboard` shows a tighter centered Sign in card
- [ ] GitHub / Google / Apple buttons share the card width and stay left-aligned
- [ ] Authorize and onboarding card width is unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure layout/CSS for the signed-out dashboard card; no auth or data-flow changes.
> 
> **Overview**
> Makes the signed-out `/dashboard` sign-in card a dedicated **narrow** `AuthShell` so title, copy, and provider buttons sit in one tighter column.
> 
> `AuthShell` now accepts `size="narrow"` (384px) with denser header typography. Social buttons stretch full width and left-align. Authorize and onboarding keep the default compact width. Copy is tweaked to “Continue with the account on your Wrapper profile.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527c07e6e616cf8da7d0a88943c4ca2cee0a5b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->