### PR TITLE
chore(release): prepare CLI v0.1.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "bin": {
     "wrapper": "./index.ts"

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/cli": {
       "name": "@repo/cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "wrapper": "./index.ts",
       },


### PR DESCRIPTION
## Summary
- bump the CLI and workspace lock version to 0.1.1
- publish the production Convex endpoint defaults already merged to main

## Test plan
- [x] CLI unit and integration tests
- [x] CLI typecheck, lint, and format check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Package version metadata only; no runtime, auth, or data-handling changes.
> 
> **Overview**
> Bumps `@repo/cli` from `0.1.0` to `0.1.1` in `package.json` and `bun.lock` to prepare the next CLI release. No code or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1e5abb86e384cd736378e986ec7b7ed2846b46f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->