### PR TITLE
fix(release): preserve production defaults in CLI binaries

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -144,7 +144,14 @@ jobs:
       - name: Build standalone binary
         run: |
           mkdir -p dist
-          bun build --compile --env=disable --target="${{ matrix.target }}" apps/cli/index.ts --outfile dist/wrapper
+          bun build \
+            --compile \
+            --env=disable \
+            --no-compile-autoload-dotenv \
+            --no-compile-autoload-bunfig \
+            --target="${{ matrix.target }}" \
+            apps/cli/index.ts \
+            --outfile dist/wrapper
 
       - name: Verify native release version
         if: matrix.platform == 'linux-x64'

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Build standalone binary
         run: |
           mkdir -p dist
-          bun build --compile --target="${{ matrix.target }}" apps/cli/index.ts --outfile dist/wrapper
+          bun build --compile --env=disable --target="${{ matrix.target }}" apps/cli/index.ts --outfile dist/wrapper
 
       - name: Verify native release version
         if: matrix.platform == 'linux-x64'

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build standalone binary
         run: |
           mkdir -p dist
-          bun build --compile --target="${{ matrix.target }}" apps/cli/index.ts --outfile dist/wrapper
+          bun build --compile --env=disable --target="${{ matrix.target }}" apps/cli/index.ts --outfile dist/wrapper
 
       - name: Verify native release version
         if: matrix.platform == 'linux-x64'

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -59,7 +59,14 @@ jobs:
       - name: Build standalone binary
         run: |
           mkdir -p dist
-          bun build --compile --env=disable --target="${{ matrix.target }}" apps/cli/index.ts --outfile dist/wrapper
+          bun build \
+            --compile \
+            --env=disable \
+            --no-compile-autoload-dotenv \
+            --no-compile-autoload-bunfig \
+            --target="${{ matrix.target }}" \
+            apps/cli/index.ts \
+            --outfile dist/wrapper
 
       - name: Verify native release version
         if: matrix.platform == 'linux-x64'

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "bin": {
     "wrapper": "./index.ts"

--- a/apps/cli/scripts/smoke-release-binary.py
+++ b/apps/cli/scripts/smoke-release-binary.py
@@ -19,6 +19,9 @@ def main() -> None:
     binary = args.binary.resolve()
 
     with tempfile.TemporaryDirectory(prefix="wrapper-release-smoke-") as home:
+        project = Path(home) / "project"
+        project.mkdir()
+        (project / ".env").write_text("NODE_ENV=development\n", encoding="utf-8")
         env = {
             **os.environ,
             "HOME": home,
@@ -28,6 +31,7 @@ def main() -> None:
         env.pop("NODE_ENV", None)
         process = subprocess.Popen(
             [str(binary), "shell-host", "--shell", "/bin/sh"],
+            cwd=project,
             env=env,
             start_new_session=True,
             stderr=subprocess.PIPE,
@@ -59,10 +63,10 @@ def main() -> None:
         )
         if not production_registry.is_file() or development_registry.exists():
             raise SystemExit(
-                "release binary did not use production defaults with NODE_ENV unset"
+                "release binary loaded project dotenv or missed production defaults"
             )
 
-    print(f"verified native PTY startup and production defaults: {binary}")
+    print(f"verified isolated native PTY production defaults: {binary}")
 
 
 if __name__ == "__main__":

--- a/apps/cli/scripts/smoke-release-binary.py
+++ b/apps/cli/scripts/smoke-release-binary.py
@@ -22,10 +22,10 @@ def main() -> None:
         env = {
             **os.environ,
             "HOME": home,
-            "NODE_ENV": "production",
             "SHELL": "/bin/sh",
             "WRAPPER_LOG": "off",
         }
+        env.pop("NODE_ENV", None)
         process = subprocess.Popen(
             [str(binary), "shell-host", "--shell", "/bin/sh"],
             env=env,
@@ -51,7 +51,18 @@ def main() -> None:
                 os.killpg(process.pid, signal.SIGKILL)
                 process.wait(timeout=5)
 
-    print(f"verified native PTY startup: {binary}")
+        production_registry = (
+            Path(home) / ".local" / "state" / "wrapper" / "sessions.json"
+        )
+        development_registry = (
+            Path(home) / ".local" / "state" / "wrapper-dev" / "sessions.json"
+        )
+        if not production_registry.is_file() or development_registry.exists():
+            raise SystemExit(
+                "release binary did not use production defaults with NODE_ENV unset"
+            )
+
+    print(f"verified native PTY startup and production defaults: {binary}")
 
 
 if __name__ == "__main__":

--- a/apps/cli/tests/release-workflows.test.ts
+++ b/apps/cli/tests/release-workflows.test.ts
@@ -113,8 +113,11 @@ describe("CLI release workflows", () => {
   test("dry run verifies the complete checksum set without publishing", () => {
     expect(dryRunWorkflow).toContain("Verify release asset set");
     expect(dryRunWorkflow).toContain("sha256sum --check checksums.txt");
-    expect(dryRunWorkflow).toContain("bun build --compile --env=disable");
-    expect(releaseWorkflow).toContain("bun build --compile --env=disable");
+    for (const workflow of [dryRunWorkflow, releaseWorkflow]) {
+      expect(workflow).toContain("--env=disable");
+      expect(workflow).toContain("--no-compile-autoload-dotenv");
+      expect(workflow).toContain("--no-compile-autoload-bunfig");
+    }
     expect(dryRunWorkflow).toContain("COPYFILE_DISABLE=1 tar");
     expect(releaseWorkflow).toContain("COPYFILE_DISABLE=1 tar");
     expect(dryRunWorkflow).toContain("smoke-release-binary.py");

--- a/apps/cli/tests/release-workflows.test.ts
+++ b/apps/cli/tests/release-workflows.test.ts
@@ -113,6 +113,8 @@ describe("CLI release workflows", () => {
   test("dry run verifies the complete checksum set without publishing", () => {
     expect(dryRunWorkflow).toContain("Verify release asset set");
     expect(dryRunWorkflow).toContain("sha256sum --check checksums.txt");
+    expect(dryRunWorkflow).toContain("bun build --compile --env=disable");
+    expect(releaseWorkflow).toContain("bun build --compile --env=disable");
     expect(dryRunWorkflow).toContain("COPYFILE_DISABLE=1 tar");
     expect(releaseWorkflow).toContain("COPYFILE_DISABLE=1 tar");
     expect(dryRunWorkflow).toContain("smoke-release-binary.py");

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/cli": {
       "name": "@repo/cli",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "wrapper": "./index.ts",
       },


### PR DESCRIPTION
## Summary
- stop Bun from embedding development mode into compiled CLI binaries
- verify release binaries use production defaults when NODE_ENV is unset
- prepare the corrected v0.1.2 patch release

## Test plan
- [x] 69 CLI tests
- [x] CLI typecheck, lint, and format check
- [x] compiled macOS ARM64 production-default smoke test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how shipped CLI binaries are compiled and which runtime defaults they use (state paths, NODE_ENV). Incorrect flags would ship binaries that still pick up development mode.
> 
> **Overview**
> Stops Bun from baking development env/dotenv/bunfig into standalone CLI binaries, so shipped wrappers keep production defaults (`wrapper` state, not `wrapper-dev`) even when `NODE_ENV` is unset.
> 
> Release and dry-run compile steps now pass `--env=disable`, `--no-compile-autoload-dotenv`, and `--no-compile-autoload-bunfig`. The native smoke test plants a project `.env` with `NODE_ENV=development` and asserts the binary still writes the production session registry.
> 
> Bumps the CLI to **0.1.2** for a patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 811681e35c2886ec0460920c47f28d09c0fe7d45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->