### PR TITLE
fix(backend): send plan and deletion emails only once

### DIFF
--- a/packages/backend/convex/appleNotifications.ts
+++ b/packages/backend/convex/appleNotifications.ts
@@ -4,6 +4,8 @@ import { components } from "./_generated/api";
 import { type ActionCtx, internalAction, internalMutation } from "./_generated/server";
 import { deleteAllPaginated, deleteAuthRecordsForUser } from "./lib/accountDeletion.ts";
 import { createLogger } from "./lib/logger.ts";
+import { EmailKind } from "./lib/types.ts";
+import { sendEmailDirect } from "./resend.ts";
 
 const log = createLogger("apple-notifications");
 const EVENT_RETENTION_MS = 90 * 24 * 60 * 60 * 1_000;
@@ -356,10 +358,21 @@ async function deleteAppleOnlyUser(ctx: ActionCtx, userId: string): Promise<void
     where: [{ field: "_id", operator: "eq", value: userId }],
   })) as { email: string; name?: string | null } | null;
 
-  await ctx.runMutation(deleteOwnedDataRef, { userId });
+  const counts = await ctx.runMutation(deleteOwnedDataRef, { userId });
   await ctx.runMutation(queueBillingCustomerDeletionRef, { userId });
   await deleteSessionsForUser(ctx, userId);
   if (!user) return;
+
+  try {
+    await sendEmailDirect(user.email, {
+      kind: EmailKind.AccountDeleted,
+      userName: user.name || "there",
+      sessionsDeleted: counts.sessions,
+      ticketsRevoked: counts.relayTickets,
+    });
+  } catch {
+    log.error("Failed to send account deletion email");
+  }
 
   await deleteAuthRecordsForUser({
     deletePage: async (request, paginationOpts) =>

--- a/packages/backend/convex/appleNotifications.ts
+++ b/packages/backend/convex/appleNotifications.ts
@@ -4,8 +4,6 @@ import { components } from "./_generated/api";
 import { type ActionCtx, internalAction, internalMutation } from "./_generated/server";
 import { deleteAllPaginated, deleteAuthRecordsForUser } from "./lib/accountDeletion.ts";
 import { createLogger } from "./lib/logger.ts";
-import { EmailKind } from "./lib/types.ts";
-import { sendEmailDirect } from "./resend.ts";
 
 const log = createLogger("apple-notifications");
 const EVENT_RETENTION_MS = 90 * 24 * 60 * 60 * 1_000;
@@ -358,21 +356,10 @@ async function deleteAppleOnlyUser(ctx: ActionCtx, userId: string): Promise<void
     where: [{ field: "_id", operator: "eq", value: userId }],
   })) as { email: string; name?: string | null } | null;
 
-  const counts = await ctx.runMutation(deleteOwnedDataRef, { userId });
+  await ctx.runMutation(deleteOwnedDataRef, { userId });
   await ctx.runMutation(queueBillingCustomerDeletionRef, { userId });
   await deleteSessionsForUser(ctx, userId);
   if (!user) return;
-
-  try {
-    await sendEmailDirect(user.email, {
-      kind: EmailKind.AccountDeleted,
-      userName: user.name || "there",
-      sessionsDeleted: counts.sessions,
-      ticketsRevoked: counts.relayTickets,
-    });
-  } catch {
-    log.error("Failed to send account deletion email");
-  }
 
   await deleteAuthRecordsForUser({
     deletePage: async (request, paginationOpts) =>

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -90,6 +90,7 @@ export default defineSchema({
     hasPro: v.optional(v.boolean()),
     planDowngradedAt: v.optional(v.number()),
     gracePeriodEmailSent: v.optional(v.boolean()),
+    planUpgradedEmailSent: v.optional(v.boolean()),
     accessRestrictedEmailSent: v.optional(v.boolean()),
   })
     .index("by_user", ["userId"])

--- a/packages/backend/convex/user.ts
+++ b/packages/backend/convex/user.ts
@@ -37,11 +37,19 @@ export const _upgradeToPro = internalMutation({
   args: {
     userId: v.string(),
   },
+  returns: v.object({
+    success: v.boolean(),
+    claimedUpgradeEmail: v.boolean(),
+  }),
   handler: async (ctx, args) => {
     const existing = await ctx.db
       .query("emailState")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
       .first();
+    if (existing?.hasPro === true) {
+      return { success: true, claimedUpgradeEmail: false };
+    }
+
     const patch = {
       hasPro: true,
       planDowngradedAt: undefined,
@@ -50,10 +58,10 @@ export const _upgradeToPro = internalMutation({
     };
     if (existing) {
       await ctx.db.patch(existing._id, patch);
-      return { success: true };
+      return { success: true, claimedUpgradeEmail: true };
     }
     await ctx.db.insert("emailState", { userId: args.userId, hasPro: true });
-    return { success: true };
+    return { success: true, claimedUpgradeEmail: true };
   },
 });
 
@@ -232,11 +240,18 @@ export const _handlePlanUpgrade = internalAction({
   handler: async (ctx, args) => {
     const user = await loadAuthUser(ctx, args.userId);
 
-    await ctx.runMutation(internal.user._upgradeToPro, {
+    const upgrade = await ctx.runMutation(internal.user._upgradeToPro, {
       userId: user._id,
     });
 
-    log.info("User upgraded to Pro", { userId: user._id });
+    log.info("User upgraded to Pro", {
+      userId: user._id,
+      claimedUpgradeEmail: upgrade.claimedUpgradeEmail,
+    });
+
+    if (!upgrade.claimedUpgradeEmail) {
+      return;
+    }
 
     await sendEmail(ctx, user._id, user.email, {
       kind: EmailKind.PlanUpgraded,

--- a/packages/backend/convex/user.ts
+++ b/packages/backend/convex/user.ts
@@ -46,7 +46,7 @@ export const _upgradeToPro = internalMutation({
       .query("emailState")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
       .first();
-    if (existing?.hasPro === true) {
+    if (existing?.hasPro === true && existing.planUpgradedEmailSent === true) {
       return { success: true, claimedUpgradeEmail: false };
     }
 
@@ -54,14 +54,36 @@ export const _upgradeToPro = internalMutation({
       hasPro: true,
       planDowngradedAt: undefined,
       gracePeriodEmailSent: undefined,
+      planUpgradedEmailSent: true,
       accessRestrictedEmailSent: undefined,
     };
     if (existing) {
       await ctx.db.patch(existing._id, patch);
       return { success: true, claimedUpgradeEmail: true };
     }
-    await ctx.db.insert("emailState", { userId: args.userId, hasPro: true });
+    await ctx.db.insert("emailState", {
+      userId: args.userId,
+      hasPro: true,
+      planUpgradedEmailSent: true,
+    });
     return { success: true, claimedUpgradeEmail: true };
+  },
+});
+
+export const _releaseUpgradeEmail = internalMutation({
+  args: {
+    userId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("emailState")
+      .withIndex("by_user", (q) => q.eq("userId", args.userId))
+      .first();
+    if (existing?.hasPro === true && existing.planUpgradedEmailSent === true) {
+      await ctx.db.patch(existing._id, { planUpgradedEmailSent: undefined });
+    }
+    return null;
   },
 });
 
@@ -106,6 +128,7 @@ export const _downgradeToFree = internalMutation({
       hasPro: false,
       planDowngradedAt: now,
       gracePeriodEmailSent: true,
+      planUpgradedEmailSent: undefined,
       accessRestrictedEmailSent: undefined,
     };
     if (existing) {
@@ -253,10 +276,22 @@ export const _handlePlanUpgrade = internalAction({
       return;
     }
 
-    await sendEmail(ctx, user._id, user.email, {
-      kind: EmailKind.PlanUpgraded,
-      userName: user.name || "there",
-    });
+    try {
+      const sent = await sendEmail(ctx, user._id, user.email, {
+        kind: EmailKind.PlanUpgraded,
+        userName: user.name || "there",
+      });
+      if (sent.emailId === "skipped") {
+        await ctx.runMutation(internal.user._releaseUpgradeEmail, {
+          userId: user._id,
+        });
+      }
+    } catch (error) {
+      await ctx.runMutation(internal.user._releaseUpgradeEmail, {
+        userId: user._id,
+      });
+      throw error;
+    }
   },
 });
 

--- a/packages/backend/convex/user.ts
+++ b/packages/backend/convex/user.ts
@@ -46,7 +46,14 @@ export const _upgradeToPro = internalMutation({
       .query("emailState")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
       .first();
-    if (existing?.hasPro === true && existing.planUpgradedEmailSent === true) {
+    if (existing?.hasPro === true) {
+      if (existing.planUpgradedEmailSent === false) {
+        await ctx.db.patch(existing._id, { planUpgradedEmailSent: true });
+        return { success: true, claimedUpgradeEmail: true };
+      }
+      if (existing.planUpgradedEmailSent !== true) {
+        await ctx.db.patch(existing._id, { planUpgradedEmailSent: true });
+      }
       return { success: true, claimedUpgradeEmail: false };
     }
 
@@ -81,7 +88,7 @@ export const _releaseUpgradeEmail = internalMutation({
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
       .first();
     if (existing?.hasPro === true && existing.planUpgradedEmailSent === true) {
-      await ctx.db.patch(existing._id, { planUpgradedEmailSent: undefined });
+      await ctx.db.patch(existing._id, { planUpgradedEmailSent: false });
     }
     return null;
   },

--- a/packages/backend/integration-tests/email-webhooks.test.ts
+++ b/packages/backend/integration-tests/email-webhooks.test.ts
@@ -213,4 +213,15 @@ describe("email webhook and plan state", () => {
       claimedUpgradeEmail: true,
     });
   });
+
+  test("legacy Pro rows do not claim another upgrade email", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("emailState", { userId: "legacy-pro", hasPro: true });
+    });
+    expect(await t.mutation(upgradeToProRef, { userId: "legacy-pro" })).toEqual({
+      success: true,
+      claimedUpgradeEmail: false,
+    });
+  });
 });

--- a/packages/backend/integration-tests/email-webhooks.test.ts
+++ b/packages/backend/integration-tests/email-webhooks.test.ts
@@ -26,9 +26,11 @@ const cleanupOldEventsRef = makeFunctionReference<
   Record<string, never>,
   { deleted: number }
 >("webhook:_cleanupOldEvents");
-const upgradeToProRef = makeFunctionReference<"mutation", { userId: string }, { success: boolean }>(
-  "user:_upgradeToPro",
-);
+const upgradeToProRef = makeFunctionReference<
+  "mutation",
+  { userId: string },
+  { success: boolean; claimedUpgradeEmail: boolean }
+>("user:_upgradeToPro");
 const downgradeToFreeRef = makeFunctionReference<
   "mutation",
   { userId: string },
@@ -187,6 +189,19 @@ describe("email webhook and plan state", () => {
         .withIndex("by_user", (query) => query.eq("userId", "same-user"))
         .first();
       expect(row?.gracePeriodEmailSent).toBeUndefined();
+    });
+  });
+
+  test("repeated upgrade claims the Pro email only once", async () => {
+    const t = convexTest(schema, modules);
+
+    expect(await t.mutation(upgradeToProRef, { userId: "pro-user" })).toEqual({
+      success: true,
+      claimedUpgradeEmail: true,
+    });
+    expect(await t.mutation(upgradeToProRef, { userId: "pro-user" })).toEqual({
+      success: true,
+      claimedUpgradeEmail: false,
     });
   });
 });

--- a/packages/backend/integration-tests/email-webhooks.test.ts
+++ b/packages/backend/integration-tests/email-webhooks.test.ts
@@ -31,6 +31,9 @@ const upgradeToProRef = makeFunctionReference<
   { userId: string },
   { success: boolean; claimedUpgradeEmail: boolean }
 >("user:_upgradeToPro");
+const releaseUpgradeEmailRef = makeFunctionReference<"mutation", { userId: string }, null>(
+  "user:_releaseUpgradeEmail",
+);
 const downgradeToFreeRef = makeFunctionReference<
   "mutation",
   { userId: string },
@@ -202,6 +205,12 @@ describe("email webhook and plan state", () => {
     expect(await t.mutation(upgradeToProRef, { userId: "pro-user" })).toEqual({
       success: true,
       claimedUpgradeEmail: false,
+    });
+
+    await t.mutation(releaseUpgradeEmailRef, { userId: "pro-user" });
+    expect(await t.mutation(upgradeToProRef, { userId: "pro-user" })).toEqual({
+      success: true,
+      claimedUpgradeEmail: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Stop Apple-only account deletion from sending its own deletion mail; Better Auth `onDelete` is the single sender.
- Claim the Pro upgrade email when `hasPro` first becomes true so duplicate Autumn events do not resend it.

Needed to unblock `dev` → `main` (#39), which requires conversation resolution.

## Test plan
- [ ] Quality gate and full CI lane are green
- [ ] Apple-only deletion test still removes owned sessions
- [ ] Repeated `_upgradeToPro` claims the email only once

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing webhook email paths and persistent `emailState`; wrong claim logic could suppress or duplicate Pro upgrade emails, but behavior mirrors the existing grace-period pattern and is covered by new tests.
> 
> **Overview**
> Adds **`planUpgradedEmailSent`** on `emailState` and uses it so the **Plan Upgraded** email is sent at most once per real upgrade, even when Autumn/webhooks call upgrade repeatedly.
> 
> **`_upgradeToPro`** now returns **`claimedUpgradeEmail`** (same idea as downgrade’s `claimedGraceEmail`). It claims on first transition to Pro, skips duplicate claims for users already Pro (including legacy rows with no flag), and can re-claim after **`_releaseUpgradeEmail`** sets the flag back to `false`. Downgrade clears **`planUpgradedEmailSent`** so a future upgrade can email again.
> 
> **`_handlePlanUpgrade`** only calls **`sendEmail`** when the claim succeeds; on send skip or failure it releases the claim so a retry can succeed. Integration tests cover repeat upgrades, release/re-claim, and legacy Pro rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73cb3e81e3e40f3f27390f0ec9dd8f443d856175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->