### PR TITLE
feat(web): label the iOS viewer as a TestFlight beta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ CONVEX_URL="https://your-project.convex.cloud"
 SITE_URL="http://localhost:3000"
 WRAPPER_AUTH_ORIGIN="http://localhost:3000"
 NEXT_PUBLIC_APPLE_AUTH_ENABLED="false"
+# Production: TestFlight public join URL until App Store.
+# Example: https://testflight.apple.com/join/xxxxxxxx
 NEXT_PUBLIC_IOS_APP_URL=""
 NEXT_PUBLIC_IOS_APP_LABEL=""
 

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -13,7 +13,7 @@ each one deploys. If you only want to test locally, jump to
 | **web**     | Next.js site                                           | Vercel                     | `apps/web`         |
 | **cli**     | The `wrapper` CLI (host/attach)                        | GitHub Releases / Homebrew | `apps/cli`         |
 | **docs**    | Mintlify documentation source                          | `docs.wrapper.sh`          | `apps/docs`        |
-| **mobile**  | Native iPhone/iPad viewer MVP                          | TestFlight pre-release     | `apps/mobile`      |
+| **mobile**  | Native iPhone/iPad viewer                              | TestFlight public beta     | `apps/mobile`      |
 
 ## Public domains
 
@@ -110,8 +110,14 @@ build time):
 | `NEXT_PUBLIC_CONVEX_URL`         | `…confident-fox-458.convex.cloud`      | `…sleek-echidna-539.convex.cloud`      | `…sleek-echidna-539.convex.cloud`  |
 | `NEXT_PUBLIC_CONVEX_SITE_URL`    | `…confident-fox-458.convex.site`       | `…sleek-echidna-539.convex.site`       | `…sleek-echidna-539.convex.site`   |
 | `NEXT_PUBLIC_APPLE_AUTH_ENABLED` | `true` after Apple OAuth is configured | `true` after Apple OAuth is configured | `false` unless testing Apple OAuth |
-| `NEXT_PUBLIC_IOS_APP_URL`        | App Store or TestFlight URL when live  | same, or empty to use the docs fallback | empty uses the mobile viewer guide |
+| `NEXT_PUBLIC_IOS_APP_URL`        | TestFlight public join URL until App Store | same, or empty for docs fallback | empty uses the mobile viewer guide |
 | `NEXT_PUBLIC_IOS_APP_LABEL`      | optional CTA override                  | optional CTA override                  | optional CTA override              |
+
+`NEXT_PUBLIC_*` is baked at build time. After creating a TestFlight public
+link, set Production `NEXT_PUBLIC_IOS_APP_URL` to
+`https://testflight.apple.com/join/<id>` and redeploy the web app. Until that
+value is set, landing CTAs stay labeled as the iOS beta and open the
+[mobile viewer guide](https://docs.wrapper.sh/guides/mobile-viewer).
 
 ### GitHub Environments (`dev`, `production`): backend and relay only
 
@@ -227,6 +233,12 @@ build time):
 7. **Docs**: `apps/docs` is connected to Mintlify at `https://docs.wrapper.sh`.
    Keep DNS, TLS, and representative page requests healthy after navigation or
    domain changes.
+
+8. **iOS TestFlight public beta**: upload a **Release** build (prod Convex and
+   relay), add it to an **External** testing group, complete Beta App Review,
+   then **Enable Public Link**. Set Vercel Production
+   `NEXT_PUBLIC_IOS_APP_URL` to that `testflight.apple.com/join/…` URL and
+   redeploy. Do not put an Internal-only invite on the website.
 
 Once done, a push to `dev` updates matching dev backend/relay paths and creates a
 Vercel Preview. A merge to `main` updates matching production backend/relay

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The active focus is operational hardening:
 
 - rotate `HOMEBREW_TAP_TOKEN` so release workflow can keep the tap in sync
 - keep dependency audit, lint, format, types, auth, and relay checks green
-- complete App Store review and publish the public iOS listing
+- complete the TestFlight public beta for the iOS viewer, then App Store review
 - finish the remaining hosted-ops items in [`OPERATIONS.md`](./OPERATIONS.md)
 
 ## Local development

--- a/apps/docs/guides/installation.mdx
+++ b/apps/docs/guides/installation.mdx
@@ -33,11 +33,11 @@ Confirm:
 wrapper --version
 ```
 
-## Get the iOS viewer
+## Get the iOS viewer beta
 
-The iPhone and iPad app is a viewer, not a host. The shell, files, and
-credentials stay on the Mac or Linux machine. After the CLI is installed and a
-session is shared, attach from iOS.
+The iPhone and iPad app is a TestFlight viewer, not a host. The shell, files,
+and credentials stay on the Mac or Linux machine. After the CLI is installed
+and a session is shared, attach from iOS.
 
 See [Mobile viewer](/guides/mobile-viewer).
 

--- a/apps/docs/guides/mobile-viewer.mdx
+++ b/apps/docs/guides/mobile-viewer.mdx
@@ -9,9 +9,12 @@ host. Commands entered on mobile execute on that host.
 
 ## Get the app
 
-The public App Store listing is not live yet. When it ships, the download
-control appears on [wrapper.sh](https://www.wrapper.sh/#start). Until then,
-use a TestFlight or internal build and continue with this guide.
+The iOS viewer is a **TestFlight beta**. It is a viewer, not a host: the
+shell, files, processes, and credentials stay on the Mac or Linux machine.
+
+Join from [wrapper.sh](https://www.wrapper.sh/#start) when the public
+TestFlight link is live, or install a TestFlight build and continue with this
+guide. The public App Store listing is not available yet.
 
 The app requires iOS or iPadOS 18 or later and a shared host session.
 

--- a/apps/docs/reference/architecture.mdx
+++ b/apps/docs/reference/architecture.mdx
@@ -14,7 +14,7 @@ description: "How CLI, Convex, relay, web, and protocol fit together."
 | `packages/protocol` | Shared JSON message schema and codec (`protocolVersion: 1`)             |
 | `packages/terminal` | Bun-native PTY layer via `wrapper-pty-helper`                           |
 | `packages/logger`   | Logging and opt-in telemetry                                            |
-| `apps/mobile`       | Native iPhone/iPad viewer MVP; pre-TestFlight and physical-device QA    |
+| `apps/mobile`       | Native iPhone/iPad viewer; TestFlight public beta                       |
 
 ## High-level flow
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -19,8 +19,10 @@ login flow.
   becomes a normal vertical story with no pinning or smooth-scroll runtime.
   Visual tokens, motion rules, and voice guidance live in [`BRAND.md`](BRAND.md).
   The start panel keeps CLI install (`brew` / `curl`) as the host path and adds
-  an iOS viewer CTA. `NEXT_PUBLIC_IOS_APP_URL` points at App Store or TestFlight
-  when live; otherwise the CTA falls back to the mobile viewer docs.
+  an iOS viewer CTA. While the viewer is in TestFlight, that CTA is labeled as
+  the iOS beta. `NEXT_PUBLIC_IOS_APP_URL` should be the public TestFlight join
+  URL; otherwise it falls back to the mobile viewer docs. Switch it to the App
+  Store listing when that ships.
 - **Dashboard** (`app/dashboard`): a sidebar-based nested workspace with separate
   profile, active sessions, billing, and data/deletion routes. `/dashboard`
   opens the profile page, and incomplete onboarding redirects to the required

--- a/apps/web/app/dashboard/sessions/page.tsx
+++ b/apps/web/app/dashboard/sessions/page.tsx
@@ -83,8 +83,8 @@ export default async function DashboardSessionsPage() {
 
       {sessions && sessions.length > 0 ? (
         <aside className="dashboardNotice dashboardViewerNotice">
-          <strong>Open in the iOS viewer</strong>
-          <p>Your shell stays on the host. The iOS viewer attaches only after you share.</p>
+          <strong>Open in the iOS viewer beta</strong>
+          <p>Your shell stays on the host. The TestFlight viewer attaches only after you share.</p>
           <IosViewerCta variant="badge" />
         </aside>
       ) : null}

--- a/apps/web/app/landing.css
+++ b/apps/web/app/landing.css
@@ -866,6 +866,19 @@ html.lenis body {
   line-height: 1;
 }
 
+.iosViewerCtaBetaMark {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 2px;
+  padding: 3px 6px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.16);
+  font-size: 0.62rem;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .iosViewerCtaStore {
   padding: 0 16px;
   border-radius: var(--radius-pill);
@@ -916,7 +929,7 @@ html.lenis body {
 }
 
 .iosViewerCtaNote {
-  max-width: 280px;
+  max-width: 320px;
   color: var(--color-text-muted);
   font-size: 0.7rem;
   line-height: 1.45;
@@ -936,6 +949,10 @@ html.lenis body {
   .iosViewerCtaStore {
     background: #fff;
     color: #000;
+  }
+
+  .iosViewerCtaStore .iosViewerCtaBetaMark {
+    background: rgba(0, 0, 0, 0.08);
   }
 }
 

--- a/apps/web/app/support/page.tsx
+++ b/apps/web/app/support/page.tsx
@@ -30,7 +30,7 @@ export default function SupportPage() {
             . DMs are open.
           </li>
           <li>
-            The iOS viewer attaches to a shared host session. See the{" "}
+            The iOS viewer is in TestFlight beta and attaches to a shared host session. See the{" "}
             <a href="https://docs.wrapper.sh/guides/mobile-viewer">mobile viewer guide</a>.
           </li>
           <li>

--- a/apps/web/components/horizontal-landing.tsx
+++ b/apps/web/components/horizontal-landing.tsx
@@ -37,7 +37,7 @@ export function HorizontalLanding() {
                 </a>
                 <IosViewerCta variant="badge" className="landingHeroViewer" />
               </div>
-              <p className="landingMicrocopy revealItem">macOS and Linux · iPhone or iPad</p>
+              <p className="landingMicrocopy revealItem">macOS and Linux · iOS viewer beta</p>
             </div>
 
             <div className="landingHeroMedia revealItem">
@@ -278,7 +278,7 @@ export function HorizontalLanding() {
                   </div>
                 </div>
                 <div className="landingInstallMethod revealItem">
-                  <p className="landingInstallLabel">Viewer · iPhone or iPad</p>
+                  <p className="landingInstallLabel">Viewer · iPhone or iPad beta</p>
                   <IosViewerCta variant="badge" note />
                 </div>
               </div>

--- a/apps/web/components/ios-viewer-cta.tsx
+++ b/apps/web/components/ios-viewer-cta.tsx
@@ -35,12 +35,9 @@ export function IosViewerCta({ variant = "badge", className, note = false }: Ios
       >
         {storeLike ? <AppleMark /> : null}
         <span>{target.label}</span>
+        {target.beta && storeLike ? <span className="iosViewerCtaBetaMark">Beta</span> : null}
       </a>
-      {note ? (
-        <small className="iosViewerCtaNote">
-          iOS 18+ · needs a shared host session. The shell stays on the host.
-        </small>
-      ) : null}
+      {note ? <small className="iosViewerCtaNote">{target.note}</small> : null}
     </span>
   );
 }

--- a/apps/web/components/site-footer.tsx
+++ b/apps/web/components/site-footer.tsx
@@ -14,7 +14,7 @@ function footerGroups() {
           external: true,
         },
         { href: "/#start", label: "Install" },
-        { href: ios.href, label: "Get iOS viewer", external: ios.external },
+        { href: ios.href, label: ios.navLabel, external: ios.external },
         { href: "https://github.com/heycupola/wrapper", label: "GitHub", external: true },
       ],
     },
@@ -41,7 +41,7 @@ function IosViewerCompactLink() {
   const ios = getIosAppTarget();
   return (
     <a href={ios.href} target="_blank" rel="noopener noreferrer">
-      Get iOS viewer
+      {ios.navLabel}
     </a>
   );
 }

--- a/apps/web/lib/ios-app.ts
+++ b/apps/web/lib/ios-app.ts
@@ -5,11 +5,18 @@ export type IosAppKind = "store" | "testflight" | "docs";
 export type IosAppTarget = {
   href: string;
   label: string;
+  navLabel: string;
   kind: IosAppKind;
   external: boolean;
+  beta: boolean;
+  note: string;
 };
 
 type PublicEnvironment = Readonly<Record<string, string | undefined>>;
+
+const STORE_NOTE = "iOS 18+ · needs a shared host session. The shell stays on the host.";
+const BETA_NOTE =
+  "Beta · TestFlight · iOS 18+ · needs a shared host session. The shell stays on the host.";
 
 export function getIosAppTarget(environment: PublicEnvironment = process.env): IosAppTarget {
   const href = sanitizeHttpUrl(environment.NEXT_PUBLIC_IOS_APP_URL);
@@ -18,18 +25,25 @@ export function getIosAppTarget(environment: PublicEnvironment = process.env): I
   if (!href) {
     return {
       href: IOS_VIEWER_DOCS_URL,
-      label: label ?? "Get the iOS viewer",
+      label: label ?? "Join the iOS beta",
+      navLabel: "iOS beta",
       kind: "docs",
       external: true,
+      beta: true,
+      note: BETA_NOTE,
     };
   }
 
   const kind = href.includes("testflight.apple.com") ? "testflight" : "store";
+  const beta = kind === "testflight";
   return {
     href,
-    label: label ?? (kind === "testflight" ? "Join the iOS beta" : "Get the iOS viewer"),
+    label: label ?? (beta ? "Join the iOS beta" : "Get the iOS viewer"),
+    navLabel: beta ? "iOS beta" : "iOS viewer",
     kind,
     external: true,
+    beta,
+    note: beta ? BETA_NOTE : STORE_NOTE,
   };
 }
 

--- a/apps/web/tests/ios-app.test.ts
+++ b/apps/web/tests/ios-app.test.ts
@@ -3,12 +3,15 @@ import { describe, test } from "node:test";
 import { getIosAppTarget, IOS_VIEWER_DOCS_URL } from "../lib/ios-app";
 
 describe("iOS app target", () => {
-  test("falls back to the mobile viewer guide when no URL is set", () => {
+  test("falls back to the mobile viewer guide as a beta join when no URL is set", () => {
     assert.deepEqual(getIosAppTarget({}), {
       href: IOS_VIEWER_DOCS_URL,
-      label: "Get the iOS viewer",
+      label: "Join the iOS beta",
+      navLabel: "iOS beta",
       kind: "docs",
       external: true,
+      beta: true,
+      note: "Beta · TestFlight · iOS 18+ · needs a shared host session. The shell stays on the host.",
     });
   });
 
@@ -20,25 +23,23 @@ describe("iOS app target", () => {
       {
         href: "https://apps.apple.com/app/wrapper/id000",
         label: "Get the iOS viewer",
+        navLabel: "iOS viewer",
         kind: "store",
         external: true,
+        beta: false,
+        note: "iOS 18+ · needs a shared host session. The shell stays on the host.",
       },
     );
   });
 
   test("labels TestFlight URLs as a beta join", () => {
-    assert.equal(
-      getIosAppTarget({
-        NEXT_PUBLIC_IOS_APP_URL: "https://testflight.apple.com/join/abcd",
-      }).kind,
-      "testflight",
-    );
-    assert.equal(
-      getIosAppTarget({
-        NEXT_PUBLIC_IOS_APP_URL: "https://testflight.apple.com/join/abcd",
-      }).label,
-      "Join the iOS beta",
-    );
+    const target = getIosAppTarget({
+      NEXT_PUBLIC_IOS_APP_URL: "https://testflight.apple.com/join/abcd",
+    });
+    assert.equal(target.kind, "testflight");
+    assert.equal(target.label, "Join the iOS beta");
+    assert.equal(target.navLabel, "iOS beta");
+    assert.equal(target.beta, true);
   });
 
   test("lets an explicit label override the default copy", () => {


### PR DESCRIPTION
## Summary
- Landing, footer, dashboard, support, and docs now treat the iOS viewer as a TestFlight beta instead of an App Store download.
- CTAs stay on the docs guide until Vercel `NEXT_PUBLIC_IOS_APP_URL` is a TestFlight public join link; the same copy then points at that URL.
- Bumps `apps/mobile` to the viewer-beta Sign in / Settings labels.

## Test plan
- [ ] `wrapper.sh` hero/install/footer say Join the iOS beta (or iOS beta) after merge + deploy
- [ ] Without `NEXT_PUBLIC_IOS_APP_URL`, CTA opens the mobile viewer docs
- [ ] With a TestFlight join URL on Vercel Production, CTA opens that URL and keeps the Beta chip
- [ ] Docs installation + mobile-viewer pages describe TestFlight, not a live App Store listing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing copy, CSS, and env documentation only; no auth, billing, or session logic changes.
> 
> **Overview**
> **Reframes the iOS viewer across the site and docs as a TestFlight public beta** instead of implying a live App Store download, while keeping the same env-driven link behavior.
> 
> `getIosAppTarget` now returns **beta-aware copy** (`navLabel`, `note`, `beta` flag): missing `NEXT_PUBLIC_IOS_APP_URL` still opens the mobile viewer guide but labels CTAs as **Join the iOS beta** / **iOS beta**; TestFlight join URLs get the same beta labels plus a **Beta** chip on store-style buttons. App Store URLs keep non-beta **Get the iOS viewer** wording for when the listing ships.
> 
> **Web surfaces** (landing hero/install, pricing line, dashboard sessions notice, footer links, support) and **Mintlify guides** are updated to say TestFlight beta. **`.env.example`**, **`ENVIRONMENTS.md`**, and **`README.md`** document setting Production `NEXT_PUBLIC_IOS_APP_URL` to a public `testflight.apple.com/join/…` link and redeploying, with a new ops checklist step for external TestFlight + public link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f466a992f92be794c6f085fd85fb532619a88697. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->