### PR TITLE
fix(web): billing portal after checkout and landing hash timing

### DIFF
--- a/apps/web/app/dashboard/billing/page.tsx
+++ b/apps/web/app/dashboard/billing/page.tsx
@@ -10,12 +10,18 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default async function DashboardBillingPage() {
+export default async function DashboardBillingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ upgraded?: string | string[] }>;
+}) {
   const token = await getToken();
   if (!token) return null;
 
+  const params = await searchParams;
+  const upgraded = Array.isArray(params.upgraded) ? params.upgraded[0] : params.upgraded;
   const billing = await getDashboardBillingState(token);
-  const canManageBilling = billing?.canManageBilling === true;
+  const canManageBilling = billing?.canManageBilling === true || upgraded === "1";
 
   return (
     <>

--- a/apps/web/components/horizontal-scroll.tsx
+++ b/apps/web/components/horizontal-scroll.tsx
@@ -193,7 +193,7 @@ export function HorizontalScroll({
         smoothWheel: true,
         wheelMultiplier: 1,
       });
-      if (window.location.hash) {
+      if (measuredSections.length > 0 && window.location.hash) {
         navigateToHash(false, true);
       }
     };


### PR DESCRIPTION
## Summary
- Show Manage billing when returning from Stripe checkout (`?upgraded=1`) even if the Autumn webhook has not written `emailState` yet.
- Apply `/#start` only after landing section metrics exist, then again once Lenis is ready.

## Test plan
- [ ] Complete Pro checkout and land on `/dashboard/billing?upgraded=1` with Manage billing visible
- [ ] From dashboard empty sessions, Install Wrapper opens the start slide rather than intro

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI gating and scroll-timing guards with no auth or payment logic changes beyond showing billing controls one request earlier.
> 
> **Overview**
> Fixes two post-checkout / landing UX timing issues.
> 
> **Billing:** After Stripe Pro checkout, users land on `/dashboard/billing?upgraded=1`. The page now treats **`canManageBilling` as true** when that query flag is present, so **Manage billing** shows immediately instead of waiting for the Autumn webhook to update server-side billing state.
> 
> **Landing scroll:** When Lenis finishes loading on desktop horizontal mode, hash navigation (e.g. `/#start`) only runs if **section layout has already been measured**. That avoids scrolling to the wrong slide when metrics are still empty; hash handling still runs from the measure path once sections exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e9a16abf4004f5005047056a380168a36b61cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->