### PR TITLE
Keep Get iOS viewer copy; Beta stays a tag

### DIFF
--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -116,7 +116,7 @@ build time):
 `NEXT_PUBLIC_*` is baked at build time. After creating a TestFlight public
 link, set Production `NEXT_PUBLIC_IOS_APP_URL` to
 `https://testflight.apple.com/join/<id>` and redeploy the web app. Until that
-value is set, landing CTAs stay labeled as the iOS beta and open the
+value is set, landing CTAs stay **Get iOS viewer** with a Beta tag and open the
 [mobile viewer guide](https://docs.wrapper.sh/guides/mobile-viewer).
 
 ### GitHub Environments (`dev`, `production`): backend and relay only

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -19,10 +19,11 @@ login flow.
   becomes a normal vertical story with no pinning or smooth-scroll runtime.
   Visual tokens, motion rules, and voice guidance live in [`BRAND.md`](BRAND.md).
   The start panel keeps CLI install (`brew` / `curl`) as the host path and adds
-  an iOS viewer CTA. While the viewer is in TestFlight, that CTA is labeled as
-  the iOS beta. `NEXT_PUBLIC_IOS_APP_URL` should be the public TestFlight join
-  URL; otherwise it falls back to the mobile viewer docs. Switch it to the App
-  Store listing when that ships.
+  an iOS viewer CTA labeled **Get iOS viewer**. While the viewer is in
+  TestFlight (or falling back to docs), the CTA keeps a Beta tag; the App Store
+  listing drops that tag. `NEXT_PUBLIC_IOS_APP_URL` should be the public
+  TestFlight join URL; otherwise it falls back to the mobile viewer docs.
+  Switch it to the App Store listing when that ships.
 - **Dashboard** (`app/dashboard`): a sidebar-based nested workspace with separate
   profile, active sessions, billing, and data/deletion routes. `/dashboard`
   opens the profile page, and incomplete onboarding redirects to the required

--- a/apps/web/lib/ios-app.ts
+++ b/apps/web/lib/ios-app.ts
@@ -25,8 +25,8 @@ export function getIosAppTarget(environment: PublicEnvironment = process.env): I
   if (!href) {
     return {
       href: IOS_VIEWER_DOCS_URL,
-      label: label ?? "Join the iOS beta",
-      navLabel: "iOS beta",
+      label: label ?? "Get iOS viewer",
+      navLabel: "iOS viewer",
       kind: "docs",
       external: true,
       beta: true,
@@ -38,8 +38,8 @@ export function getIosAppTarget(environment: PublicEnvironment = process.env): I
   const beta = kind === "testflight";
   return {
     href,
-    label: label ?? (beta ? "Join the iOS beta" : "Get iOS viewer"),
-    navLabel: beta ? "iOS beta" : "iOS viewer",
+    label: label ?? "Get iOS viewer",
+    navLabel: "iOS viewer",
     kind,
     external: true,
     beta,

--- a/apps/web/tests/ios-app.test.ts
+++ b/apps/web/tests/ios-app.test.ts
@@ -6,8 +6,8 @@ describe("iOS app target", () => {
   test("falls back to the mobile viewer guide as a beta join when no URL is set", () => {
     assert.deepEqual(getIosAppTarget({}), {
       href: IOS_VIEWER_DOCS_URL,
-      label: "Join the iOS beta",
-      navLabel: "iOS beta",
+      label: "Get iOS viewer",
+      navLabel: "iOS viewer",
       kind: "docs",
       external: true,
       beta: true,
@@ -32,13 +32,13 @@ describe("iOS app target", () => {
     );
   });
 
-  test("labels TestFlight URLs as a beta join", () => {
+  test("keeps Get iOS viewer copy and marks TestFlight URLs as beta", () => {
     const target = getIosAppTarget({
       NEXT_PUBLIC_IOS_APP_URL: "https://testflight.apple.com/join/abcd",
     });
     assert.equal(target.kind, "testflight");
-    assert.equal(target.label, "Join the iOS beta");
-    assert.equal(target.navLabel, "iOS beta");
+    assert.equal(target.label, "Get iOS viewer");
+    assert.equal(target.navLabel, "iOS viewer");
     assert.equal(target.beta, true);
   });
 


### PR DESCRIPTION
## Summary
- Keep CTA and nav copy as **Get iOS viewer** / **iOS viewer** on TestFlight, docs fallback, and App Store.
- Continue showing the small Beta tag only while the target is TestFlight or docs; drop it for the App Store listing.

## Test plan
- [ ] Landing/footer CTA reads Get iOS viewer with a Beta tag on TestFlight or empty `NEXT_PUBLIC_IOS_APP_URL`
- [ ] Same CTA has no Beta tag when `NEXT_PUBLIC_IOS_APP_URL` is an App Store URL
- [ ] `bun test tests/ios-app.test.ts` in `apps/web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and documentation only; URL routing, beta flag logic, and env overrides are unchanged.
> 
> **Overview**
> Landing and nav iOS CTAs no longer switch to **Join the iOS beta** / **iOS beta** on TestFlight or when `NEXT_PUBLIC_IOS_APP_URL` is unset. **`getIosAppTarget`** now always uses **Get iOS viewer** and **iOS viewer** (unless `NEXT_PUBLIC_IOS_APP_LABEL` overrides), while **`beta: true`** still drives the separate **Beta** badge for docs fallback and TestFlight URLs and stays off for App Store links.
> 
> **`ENVIRONMENTS.md`** and **`apps/web/README.md`** are updated to match that behavior. Unit tests in **`ios-app.test.ts`** reflect the new defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bc9b6c31cb39e6d5bf76b811bbf35d4fd0f6452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->