### PR TITLE
chore(release): prepare CLI v0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The separate `apps/mobile` submodule now contains a Simulator-ready native
 iPhone/iPad viewer MVP: device authorization, owner and guest join flows,
 SwiftTerm rendering, relay transport, native WebRTC, and adaptive navigation.
 It uses Swift 6.0 language mode with complete strict concurrency on Xcode 26.
-CLI `v0.1.2` is published on GitHub Releases. Signed-device validation and App
+CLI `v0.1.3` is published on GitHub Releases. Signed-device validation and App
 Store review remain pre-release work.
 
 The active focus is operational hardening:

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "license": "MIT",
   "bin": {

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/cli": {
       "name": "@repo/cli",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "bin": {
         "wrapper": "./index.ts",
       },


### PR DESCRIPTION
## Summary
- Bump the CLI from `0.1.2` to `0.1.3` so GitHub Releases and Homebrew can ship the updates since v0.1.2 (login UX, configurable share prefix, and related CLI fixes).
- Merging this to `main` starts the `Release CLI` workflow.

## Test plan
- [ ] Quality gate and full lane are green
- [ ] After merge to `main`, `Release CLI` publishes `v0.1.3` with darwin/linux archives
- [ ] `wrapper --version` on the published binary is `0.1.3`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no application logic; release automation runs on merge.
> 
> **Overview**
> Bumps **`@repo/cli`** from **0.1.2** to **0.1.3** in `apps/cli/package.json` and the matching **`bun.lock`** entry, and updates the README status line to say CLI **v0.1.3** is published on GitHub Releases.
> 
> There are no runtime or feature changes in this diff—it is release metadata only. After merge to **`main`**, the **`Release CLI`** workflow (triggered by changes under `apps/cli/**`) should publish **v0.1.3** archives and keep Homebrew in sync with the version already shipped in prior commits (login UX, share prefix, and related fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 063d23f6db944560f536c11c82178c56ef188101. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->