### PR TITLE
chore(release): prepare CLI v0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The separate `apps/mobile` submodule now contains a Simulator-ready native
 iPhone/iPad viewer MVP: device authorization, owner and guest join flows,
 SwiftTerm rendering, relay transport, native WebRTC, and adaptive navigation.
 It uses Swift 6.0 language mode with complete strict concurrency on Xcode 26.
-CLI `v0.1.2` is published on GitHub Releases. Signed-device validation and App
+CLI `v0.1.3` is published on GitHub Releases. Signed-device validation and App
 Store review remain pre-release work.
 
 The active focus is operational hardening:

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "license": "MIT",
   "bin": {

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/cli": {
       "name": "@repo/cli",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "bin": {
         "wrapper": "./index.ts",
       },


### PR DESCRIPTION
## Summary
- Bump the CLI from `0.1.2` to `0.1.3`.
- Merging to `main` starts the `Release CLI` workflow (GitHub Release + Homebrew tap).

## Test plan
- [ ] Quality gate and full lane are green
- [ ] `Release CLI` publishes `v0.1.3`
- [ ] `wrapper --version` on the published binary is `0.1.3`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no application logic modified.
> 
> **Overview**
> Prepares a **CLI v0.1.3** release by bumping `@repo/cli` from `0.1.2` to `0.1.3` in `apps/cli/package.json`, syncing `bun.lock`, and updating the published version called out in `README.md`.
> 
> There are no runtime or feature changes in this diff—merging to `main` is intended to kick off the existing **Release CLI** workflow (GitHub Release + Homebrew tap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5c5cb13559fc46a0bdf34833617d7b3c2c06d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->