### PR TITLE
Land dashboard Install on the last scene and show plan on profile

### DIFF
--- a/apps/docs/reference/pricing.mdx
+++ b/apps/docs/reference/pricing.mdx
@@ -11,8 +11,8 @@ description: "Free local wrapping and Pro remote sharing."
 | Pro  | $20 / month | Remote relay sharing (`can_share_relay`)   |
 
 Upgrade from the signed-in [dashboard billing](https://www.wrapper.sh/dashboard/billing)
-page. Stripe's customer portal is available after the first Pro checkout; free
-accounts only see upgrade.
+page. Profile shows Free or Pro. Stripe's customer portal is available after
+the first Pro checkout; free accounts only see upgrade.
 
 ## What Pro unlocks
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -14,7 +14,9 @@ login flow.
   `requestAnimationFrame` writes the compositor-backed `translate3d`. The track
   remains continuous and never snaps between scenes. Hash links map each
   section back to its vertical document coordinate without adding visible
-  navigation chrome.
+  navigation chrome. Dashboard Install links remember the install scene and
+  open `/` without a hash, then lock that last scene until the track and Lenis
+  catch up. In-page hero/header CTAs still use `#start`.
   Below 1024px, and whenever reduced motion is requested, the same semantic DOM
   becomes a normal vertical story with no pinning or smooth-scroll runtime.
   Visual tokens, motion rules, and voice guidance live in [`BRAND.md`](BRAND.md).
@@ -29,8 +31,8 @@ login flow.
   opens the profile page, and incomplete onboarding redirects to the required
   setup flow before dashboard content renders. Sessions use the real
   `session:listActive` query, while billing reuses the existing protected
-  checkout and portal actions. The workspace stays on a flat canvas and uses no
-  invented metrics.
+  checkout and portal actions. Profile shows the current Free or Pro plan. The
+  workspace stays on a flat canvas and uses no invented metrics.
 - **Device login approval** (`app/oauth/authorize`): the page the CLI sends you
   to during `wrapper auth login`. It reads the `user_code` from the URL,
   confirms your identity through Better Auth, presents the request as structured

--- a/apps/web/app/dashboard/billing/page.tsx
+++ b/apps/web/app/dashboard/billing/page.tsx
@@ -22,6 +22,7 @@ export default async function DashboardBillingPage({
   const upgraded = Array.isArray(params.upgraded) ? params.upgraded[0] : params.upgraded;
   const billing = await getDashboardBillingState(token);
   const canManageBilling = billing?.canManageBilling === true || upgraded === "1";
+  const plan = billing?.plan === "pro" || upgraded === "1" ? "pro" : "free";
 
   return (
     <>
@@ -34,7 +35,9 @@ export default async function DashboardBillingPage({
         <article className="dashboardPanel">
           <div className="dashboardPanelHeader">
             <div>
-              <span className="dashboardPanelLabel">Included</span>
+              <span className="dashboardPanelLabel">
+                {plan === "free" ? "Current plan" : "Included"}
+              </span>
               <h2>Free</h2>
             </div>
             <strong className="dashboardPlanPrice">$0</strong>
@@ -49,7 +52,9 @@ export default async function DashboardBillingPage({
         <article className="dashboardPanel dashboardProPanel">
           <div className="dashboardPanelHeader">
             <div>
-              <span className="dashboardPanelLabel">Remote access</span>
+              <span className="dashboardPanelLabel">
+                {plan === "pro" ? "Current plan" : "Remote access"}
+              </span>
               <h2>Pro</h2>
             </div>
             <p className="dashboardPlanPrice">

--- a/apps/web/app/dashboard/profile/page.tsx
+++ b/apps/web/app/dashboard/profile/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { getToken } from "../../../lib/auth-server";
+import { getDashboardBillingState } from "../../../lib/dashboard-server";
 import { DashboardPageHeader } from "../dashboard-page-header";
 import { DashboardProfile } from "./profile-client";
 
@@ -8,14 +10,17 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default function DashboardProfilePage() {
+export default async function DashboardProfilePage() {
+  const token = await getToken();
+  const billing = token ? await getDashboardBillingState(token) : null;
+
   return (
     <>
       <DashboardPageHeader
         title="Profile"
         description="The identity currently attached to Wrapper and its authenticated services."
       />
-      <DashboardProfile />
+      <DashboardProfile plan={billing?.plan ?? null} />
     </>
   );
 }

--- a/apps/web/app/dashboard/profile/profile-client.tsx
+++ b/apps/web/app/dashboard/profile/profile-client.tsx
@@ -1,13 +1,16 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { authClient } from "../../../lib/auth-client";
+import type { DashboardPlan } from "../../../lib/dashboard-server";
 
-export function DashboardProfile() {
+export function DashboardProfile({ plan }: { plan: DashboardPlan | null }) {
   const { data: session, isPending } = authClient.useSession();
   const user = session?.user;
   const [signingOut, setSigningOut] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const planLabel = plan === "pro" ? "Pro" : plan === "free" ? "Free" : "Unavailable";
 
   async function signOut(): Promise<void> {
     setSigningOut(true);
@@ -24,16 +27,7 @@ export function DashboardProfile() {
 
   return (
     <div className="dashboardPageStack">
-      <section className="dashboardPanel" aria-labelledby="profile-details-title">
-        <div className="dashboardPanelHeader">
-          <div>
-            <span className="dashboardPanelLabel">Identity</span>
-            <h2 id="profile-details-title">Personal details</h2>
-          </div>
-          <span className="deviceStatus" data-status={user ? "approved" : "pending"}>
-            {isPending ? "Loading" : user ? "Signed in" : "Unavailable"}
-          </span>
-        </div>
+      <section className="dashboardPanel" aria-label="Profile">
         <dl className="dashboardDetails" aria-busy={isPending}>
           <div>
             <dt>Name</dt>
@@ -46,6 +40,12 @@ export function DashboardProfile() {
           <div>
             <dt>Email status</dt>
             <dd>{isPending ? "Loading…" : user?.emailVerified ? "Verified" : "Not verified"}</dd>
+          </div>
+          <div>
+            <dt>Plan</dt>
+            <dd>
+              <Link href="/dashboard/billing">{planLabel}</Link>
+            </dd>
           </div>
         </dl>
       </section>

--- a/apps/web/app/dashboard/sessions/page.tsx
+++ b/apps/web/app/dashboard/sessions/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { IosViewerCta } from "../../../components/ios-viewer-cta";
+import { InstallWrapperLink } from "../../../components/install-wrapper-link";
 import { getToken } from "../../../lib/auth-server";
 import { getDashboardSessions } from "../../../lib/dashboard-server";
 import { DashboardPageHeader } from "../dashboard-page-header";
@@ -33,9 +33,7 @@ export default async function DashboardSessionsPage() {
         <section className="dashboardEmptyState">
           <strong>No active sessions</strong>
           <p>Install Wrapper and open an interactive shell to create the first host session.</p>
-          <Link className="primaryAction" href="/#start">
-            Install Wrapper
-          </Link>
+          <InstallWrapperLink className="primaryAction">Install Wrapper</InstallWrapperLink>
         </section>
       ) : (
         <div className="dashboardSessionCards">

--- a/apps/web/app/surfaces.css
+++ b/apps/web/app/surfaces.css
@@ -330,6 +330,14 @@
   text-align: right;
 }
 
+.dashboardDetails dd a {
+  color: var(--color-text);
+  font-weight: 510;
+  text-decoration: underline;
+  text-decoration-color: var(--color-border);
+  text-underline-offset: 3px;
+}
+
 .dashboardDeleteConfirmation {
   display: grid;
   gap: 12px;

--- a/apps/web/components/horizontal-scroll-math.ts
+++ b/apps/web/components/horizontal-scroll-math.ts
@@ -24,6 +24,17 @@ export function sectionScrollTarget(
   return start + Math.min(Math.max(0, maxTranslate), Math.max(0, sectionLeft));
 }
 
+/** True once the horizontal track has laid out, so a non-intro hash is not 0. */
+export function hashMetricsReady(input: {
+  measuredCount: number;
+  maxTranslate: number;
+  sectionLeft: number;
+  isFirstSection: boolean;
+}): boolean {
+  if (input.measuredCount === 0 || input.maxTranslate <= 0) return false;
+  return input.isFirstSection || input.sectionLeft > 0;
+}
+
 export function nearestSectionIndex(
   horizontalOffset: number,
   viewportWidth: number,

--- a/apps/web/components/horizontal-scroll.tsx
+++ b/apps/web/components/horizontal-scroll.tsx
@@ -66,7 +66,7 @@ export function HorizontalScroll({
     let lenisStarted = false;
     let lockedOffset: number | null = null;
     let lockExpires = 0;
-    let pendingScene = peekLandingScene();
+    let pendingScene = peekLandingScene(sectionIds);
 
     const sectionElements = () =>
       sectionIds.flatMap((id) => {
@@ -335,13 +335,13 @@ export function HorizontalScroll({
     };
 
     const onHashChange = () => {
-      pendingScene = peekLandingScene();
+      pendingScene = peekLandingScene(sectionIds);
       lockedOffset = null;
       applyRequestedSection();
     };
 
     const onOpenInstallScene = () => {
-      pendingScene = peekLandingScene() ?? INSTALL_SCENE_ID;
+      pendingScene = INSTALL_SCENE_ID;
       applyRequestedSection();
     };
 

--- a/apps/web/components/horizontal-scroll.tsx
+++ b/apps/web/components/horizontal-scroll.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useLayoutEffect, useRef, type ReactNode } from "react";
-import { clearLandingScene, peekLandingScene } from "../lib/landing-scene";
+import {
+  clearLandingScene,
+  INSTALL_SCENE_ID,
+  OPEN_INSTALL_SCENE_EVENT,
+  peekLandingScene,
+} from "../lib/landing-scene";
 import {
   clampHorizontalOffset,
   hashMetricsReady,
@@ -127,7 +132,12 @@ export function HorizontalScroll({
       updateActiveSection(lockedOffset);
     };
 
-    const scrollToSection = (section: HTMLElement, updateHistory: boolean, immediate = false) => {
+    const scrollToSection = (
+      section: HTMLElement,
+      updateHistory: boolean,
+      immediate = false,
+      lock = false,
+    ) => {
       if (updateHistory) history.pushState(null, "", `#${section.id}`);
 
       if (!horizontalActive) {
@@ -135,7 +145,7 @@ export function HorizontalScroll({
         return;
       }
 
-      lockToSection(section);
+      if (lock) lockToSection(section);
       const target = sectionScrollTarget(storyStart, section.offsetLeft, maxTranslate);
       if (lenis) {
         lenis.scrollTo(
@@ -152,7 +162,7 @@ export function HorizontalScroll({
       if (!sectionId) return;
       const section = document.getElementById(sectionId);
       if (!section) return;
-      scrollToSection(section, updateHistory, immediate);
+      scrollToSection(section, updateHistory, immediate, true);
       clearLandingScene(sectionId);
       pendingScene = null;
     };
@@ -330,6 +340,11 @@ export function HorizontalScroll({
       applyRequestedSection();
     };
 
+    const onOpenInstallScene = () => {
+      pendingScene = peekLandingScene() ?? INSTALL_SCENE_ID;
+      applyRequestedSection();
+    };
+
     resizeObserver = new ResizeObserver(scheduleMeasure);
     resizeObserver.observe(scroller);
     resizeObserver.observe(track);
@@ -339,6 +354,7 @@ export function HorizontalScroll({
     window.addEventListener("resize", scheduleMeasure, { passive: true });
     window.addEventListener("orientationchange", scheduleMeasure);
     window.addEventListener("hashchange", onHashChange);
+    window.addEventListener(OPEN_INSTALL_SCENE_EVENT, onOpenInstallScene);
     document.addEventListener("click", onDocumentClick);
     experience.addEventListener("focusin", onFocusIn);
     desktopQuery.addEventListener("change", syncMode);
@@ -355,6 +371,7 @@ export function HorizontalScroll({
       window.removeEventListener("resize", scheduleMeasure);
       window.removeEventListener("orientationchange", scheduleMeasure);
       window.removeEventListener("hashchange", onHashChange);
+      window.removeEventListener(OPEN_INSTALL_SCENE_EVENT, onOpenInstallScene);
       document.removeEventListener("click", onDocumentClick);
       experience.removeEventListener("focusin", onFocusIn);
       desktopQuery.removeEventListener("change", syncMode);

--- a/apps/web/components/horizontal-scroll.tsx
+++ b/apps/web/components/horizontal-scroll.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect, useRef, type ReactNode } from "react";
+import { useLayoutEffect, useRef, type ReactNode } from "react";
+import { clearLandingScene, peekLandingScene } from "../lib/landing-scene";
 import {
   clampHorizontalOffset,
+  hashMetricsReady,
   horizontalStoryHeight,
   nearestSectionIndex,
   sectionScrollTarget,
@@ -11,6 +13,7 @@ import {
 
 const desktopQueryString = "(min-width: 1024px)";
 const reducedMotionQueryString = "(prefers-reduced-motion: reduce)";
+const HASH_LOCK_MS = 2000;
 
 type MeasuredSection = SectionMetric & {
   element: HTMLElement;
@@ -35,7 +38,7 @@ export function HorizontalScroll({
   const scrollerRef = useRef<HTMLElement>(null);
   const trackRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const experience = experienceRef.current;
     const scroller = scrollerRef.current;
     const track = trackRef.current;
@@ -55,13 +58,19 @@ export function HorizontalScroll({
     let resizeObserver: ResizeObserver | null = null;
     let lenis: LenisController | null = null;
     let lenisGeneration = 0;
-    let initialHashApplied = false;
+    let lenisStarted = false;
+    let lockedOffset: number | null = null;
+    let lockExpires = 0;
+    let pendingScene = peekLandingScene();
 
     const sectionElements = () =>
       sectionIds.flatMap((id) => {
         const element = document.getElementById(id);
         return element ? [element] : [];
       });
+
+    const requestedSectionId = () =>
+      pendingScene && sectionIds.includes(pendingScene) ? pendingScene : "";
 
     const updateActiveSection = (horizontalOffset: number) => {
       if (measuredSections.length === 0) return;
@@ -78,7 +87,24 @@ export function HorizontalScroll({
       renderFrame = null;
       if (!horizontalActive) return;
 
-      const offset = clampHorizontalOffset(window.scrollY, storyStart, maxTranslate);
+      let offset = clampHorizontalOffset(window.scrollY, storyStart, maxTranslate);
+      if (lockedOffset !== null) {
+        if (performance.now() < lockExpires) {
+          offset = lockedOffset;
+          const target = sectionScrollTarget(storyStart, lockedOffset, maxTranslate);
+          if (Math.abs(window.scrollY - target) <= 4) {
+            lockedOffset = null;
+            offset = clampHorizontalOffset(window.scrollY, storyStart, maxTranslate);
+          } else if (lenis) {
+            lenis.scrollTo(target, { immediate: true, force: true });
+          } else {
+            window.scrollTo({ top: target, behavior: "auto" });
+          }
+        } else {
+          lockedOffset = null;
+        }
+      }
+
       const roundedOffset = Math.round(offset * 1000) / 1000;
       track.style.transform = `translate3d(${-roundedOffset}px, 0, 0)`;
 
@@ -94,11 +120,23 @@ export function HorizontalScroll({
       renderFrame = requestAnimationFrame(render);
     };
 
+    const lockToSection = (section: HTMLElement) => {
+      lockedOffset = Math.min(maxTranslate, Math.max(0, section.offsetLeft));
+      lockExpires = performance.now() + HASH_LOCK_MS;
+      track.style.transform = `translate3d(${-lockedOffset}px, 0, 0)`;
+      updateActiveSection(lockedOffset);
+    };
+
     const scrollToSection = (section: HTMLElement, updateHistory: boolean, immediate = false) => {
-      if (!horizontalActive) return;
-      const target = sectionScrollTarget(storyStart, section.offsetLeft, maxTranslate);
       if (updateHistory) history.pushState(null, "", `#${section.id}`);
 
+      if (!horizontalActive) {
+        section.scrollIntoView({ behavior: immediate ? "auto" : "smooth", block: "start" });
+        return;
+      }
+
+      lockToSection(section);
+      const target = sectionScrollTarget(storyStart, section.offsetLeft, maxTranslate);
       if (lenis) {
         lenis.scrollTo(
           target,
@@ -109,11 +147,49 @@ export function HorizontalScroll({
       }
     };
 
-    const navigateToHash = (updateHistory = false, immediate = false) => {
-      const sectionId = decodeURIComponent(window.location.hash.slice(1));
-      if (!sectionId || !sectionIds.includes(sectionId)) return;
+    const navigateToRequested = (updateHistory = false, immediate = false) => {
+      const sectionId = requestedSectionId();
+      if (!sectionId) return;
       const section = document.getElementById(sectionId);
-      if (section) scrollToSection(section, updateHistory, immediate);
+      if (!section) return;
+      scrollToSection(section, updateHistory, immediate);
+      clearLandingScene(sectionId);
+      pendingScene = null;
+    };
+
+    const hashSectionReady = (section: HTMLElement) => {
+      if (!horizontalActive) return true;
+      return hashMetricsReady({
+        measuredCount: measuredSections.length,
+        maxTranslate,
+        sectionLeft: section.offsetLeft,
+        isFirstSection: section.id === sectionIds[0],
+      });
+    };
+
+    const applyRequestedSection = () => {
+      const sectionId = requestedSectionId();
+      if (!sectionId) return;
+      const section = document.getElementById(sectionId);
+      if (!section || !hashSectionReady(section)) return;
+      navigateToRequested(false, true);
+    };
+
+    const startLenis = async () => {
+      if (lenisStarted) return;
+      lenisStarted = true;
+      const generation = ++lenisGeneration;
+      const { default: Lenis } = await import("lenis");
+      if (generation !== lenisGeneration || !horizontalActive) return;
+      lenis = new Lenis({
+        autoRaf: true,
+        gestureOrientation: "vertical",
+        lerp: 0.12,
+        overscroll: false,
+        smoothWheel: true,
+        wheelMultiplier: 1,
+      });
+      if (pendingScene) applyRequestedSection();
     };
 
     const measure = () => {
@@ -131,17 +207,21 @@ export function HorizontalScroll({
       }));
 
       experience.style.height = `${Math.ceil(horizontalStoryHeight(viewportHeight, maxTranslate))}px`;
+      storyStart = window.scrollY + experience.getBoundingClientRect().top;
+      applyRequestedSection();
       render();
-
-      if (!initialHashApplied && window.location.hash) {
-        initialHashApplied = true;
-        requestAnimationFrame(() => navigateToHash(false, true));
-      }
+      void startLenis();
     };
 
     const scheduleMeasure = () => {
       if (measureFrame !== null) cancelAnimationFrame(measureFrame);
       measureFrame = requestAnimationFrame(measure);
+    };
+
+    const measureNow = () => {
+      if (measureFrame !== null) cancelAnimationFrame(measureFrame);
+      measureFrame = null;
+      measure();
     };
 
     const stopVerticalObserver = () => {
@@ -177,25 +257,9 @@ export function HorizontalScroll({
 
     const destroyLenis = () => {
       lenisGeneration += 1;
+      lenisStarted = false;
       lenis?.destroy();
       lenis = null;
-    };
-
-    const startLenis = async () => {
-      const generation = ++lenisGeneration;
-      const { default: Lenis } = await import("lenis");
-      if (generation !== lenisGeneration || !horizontalActive) return;
-      lenis = new Lenis({
-        autoRaf: true,
-        gestureOrientation: "vertical",
-        lerp: 0.12,
-        overscroll: false,
-        smoothWheel: true,
-        wheelMultiplier: 1,
-      });
-      if (measuredSections.length > 0 && window.location.hash) {
-        navigateToHash(false, true);
-      }
     };
 
     const clearHorizontalLayout = () => {
@@ -205,12 +269,14 @@ export function HorizontalScroll({
       maxTranslate = 0;
       storyStart = 0;
       viewportWidth = 0;
+      lockedOffset = null;
     };
 
     const syncMode = () => {
       const nextHorizontal = desktopQuery.matches && !reducedMotionQuery.matches;
       if (nextHorizontal === horizontalActive) {
         if (horizontalActive) scheduleMeasure();
+        else if (pendingScene) applyRequestedSection();
         return;
       }
 
@@ -220,12 +286,13 @@ export function HorizontalScroll({
 
       if (horizontalActive) {
         stopVerticalObserver();
-        void startLenis();
-        scheduleMeasure();
+        void scroller.offsetWidth;
+        measureNow();
       } else {
         destroyLenis();
         clearHorizontalLayout();
         startVerticalObserver();
+        if (pendingScene) applyRequestedSection();
       }
     };
 
@@ -258,7 +325,9 @@ export function HorizontalScroll({
     };
 
     const onHashChange = () => {
-      if (horizontalActive) navigateToHash();
+      pendingScene = peekLandingScene();
+      lockedOffset = null;
+      applyRequestedSection();
     };
 
     resizeObserver = new ResizeObserver(scheduleMeasure);

--- a/apps/web/components/install-wrapper-link.tsx
+++ b/apps/web/components/install-wrapper-link.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { INSTALL_SCENE_ID, rememberLandingScene } from "../lib/landing-scene";
+
+export function InstallWrapperLink({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Link
+      className={className}
+      href="/"
+      scroll={false}
+      onClick={(event) => {
+        if (
+          event.defaultPrevented ||
+          event.button !== 0 ||
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.altKey
+        ) {
+          return;
+        }
+        rememberLandingScene(INSTALL_SCENE_ID);
+        if (window.location.pathname !== "/") {
+          event.preventDefault();
+          window.location.assign("/");
+        }
+      }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/apps/web/components/install-wrapper-link.tsx
+++ b/apps/web/components/install-wrapper-link.tsx
@@ -2,7 +2,11 @@
 
 import Link from "next/link";
 import type { ReactNode } from "react";
-import { INSTALL_SCENE_ID, rememberLandingScene } from "../lib/landing-scene";
+import {
+  INSTALL_SCENE_ID,
+  OPEN_INSTALL_SCENE_EVENT,
+  rememberLandingScene,
+} from "../lib/landing-scene";
 
 export function InstallWrapperLink({
   className,
@@ -14,7 +18,7 @@ export function InstallWrapperLink({
   return (
     <Link
       className={className}
-      href="/"
+      href="/#start"
       scroll={false}
       onClick={(event) => {
         if (
@@ -28,10 +32,12 @@ export function InstallWrapperLink({
           return;
         }
         rememberLandingScene(INSTALL_SCENE_ID);
+        event.preventDefault();
         if (window.location.pathname !== "/") {
-          event.preventDefault();
           window.location.assign("/");
+          return;
         }
+        window.dispatchEvent(new Event(OPEN_INSTALL_SCENE_EVENT));
       }}
     >
       {children}

--- a/apps/web/components/site-footer.tsx
+++ b/apps/web/components/site-footer.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { getIosAppTarget } from "../lib/ios-app";
 import { CupolaMark } from "./cupola-mark";
+import { InstallWrapperLink } from "./install-wrapper-link";
 
 function footerGroups() {
   const ios = getIosAppTarget();
@@ -91,6 +92,8 @@ export function SiteFooter({ compact = false }: { compact?: boolean }) {
                   <a key={link.href} href={link.href} target="_blank" rel="noopener noreferrer">
                     {link.label}
                   </a>
+                ) : link.href === "/#start" ? (
+                  <InstallWrapperLink key={link.href}>{link.label}</InstallWrapperLink>
                 ) : (
                   <Link key={link.href} href={link.href}>
                     {link.label}

--- a/apps/web/lib/dashboard-server.ts
+++ b/apps/web/lib/dashboard-server.ts
@@ -9,8 +9,11 @@ export type DashboardOnboardingState = {
   completedAt?: number | null;
 };
 
+export type DashboardPlan = "free" | "pro";
+
 export type DashboardBillingState = {
   canManageBilling: boolean;
+  plan: DashboardPlan;
 };
 
 export type DashboardSession = {

--- a/apps/web/lib/landing-scene.ts
+++ b/apps/web/lib/landing-scene.ts
@@ -16,10 +16,12 @@ export function rememberLandingScene(id: string): void {
   }
 }
 
-export function peekLandingScene(): string | null {
-  if (typeof window === "undefined") return rememberedScene;
+export function peekLandingScene(allowedIds?: readonly string[]): string | null {
+  if (typeof window === "undefined") {
+    return rememberedScene && Date.now() < rememberedUntil ? rememberedScene : null;
+  }
   const fromHash = decodeURIComponent(window.location.hash.slice(1));
-  if (fromHash) return fromHash;
+  if (fromHash && (!allowedIds || allowedIds.includes(fromHash))) return fromHash;
   if (rememberedScene && Date.now() < rememberedUntil) return rememberedScene;
   try {
     const stored = sessionStorage.getItem(LANDING_SCENE_KEY);

--- a/apps/web/lib/landing-scene.ts
+++ b/apps/web/lib/landing-scene.ts
@@ -1,7 +1,14 @@
 export const LANDING_SCENE_KEY = "wrapper:landing-scene";
 export const INSTALL_SCENE_ID = "start";
+export const OPEN_INSTALL_SCENE_EVENT = "wrapper:open-install-scene";
+const MEMORY_TTL_MS = 2500;
+
+let rememberedScene: string | null = null;
+let rememberedUntil = 0;
 
 export function rememberLandingScene(id: string): void {
+  rememberedScene = id;
+  rememberedUntil = Date.now() + MEMORY_TTL_MS;
   try {
     sessionStorage.setItem(LANDING_SCENE_KEY, id);
   } catch {
@@ -10,12 +17,19 @@ export function rememberLandingScene(id: string): void {
 }
 
 export function peekLandingScene(): string | null {
+  if (typeof window === "undefined") return rememberedScene;
   const fromHash = decodeURIComponent(window.location.hash.slice(1));
   if (fromHash) return fromHash;
+  if (rememberedScene && Date.now() < rememberedUntil) return rememberedScene;
   try {
-    return sessionStorage.getItem(LANDING_SCENE_KEY);
+    const stored = sessionStorage.getItem(LANDING_SCENE_KEY);
+    if (stored) {
+      rememberedScene = stored;
+      rememberedUntil = Date.now() + MEMORY_TTL_MS;
+    }
+    return stored;
   } catch {
-    return null;
+    return rememberedScene && Date.now() < rememberedUntil ? rememberedScene : null;
   }
 }
 
@@ -27,4 +41,9 @@ export function clearLandingScene(id: string): void {
   } catch {
     // Ignore quota / private-mode failures.
   }
+}
+
+export function resetLandingSceneMemory(): void {
+  rememberedScene = null;
+  rememberedUntil = 0;
 }

--- a/apps/web/lib/landing-scene.ts
+++ b/apps/web/lib/landing-scene.ts
@@ -1,0 +1,30 @@
+export const LANDING_SCENE_KEY = "wrapper:landing-scene";
+export const INSTALL_SCENE_ID = "start";
+
+export function rememberLandingScene(id: string): void {
+  try {
+    sessionStorage.setItem(LANDING_SCENE_KEY, id);
+  } catch {
+    // Ignore quota / private-mode failures.
+  }
+}
+
+export function peekLandingScene(): string | null {
+  const fromHash = decodeURIComponent(window.location.hash.slice(1));
+  if (fromHash) return fromHash;
+  try {
+    return sessionStorage.getItem(LANDING_SCENE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function clearLandingScene(id: string): void {
+  try {
+    if (sessionStorage.getItem(LANDING_SCENE_KEY) === id) {
+      sessionStorage.removeItem(LANDING_SCENE_KEY);
+    }
+  } catch {
+    // Ignore quota / private-mode failures.
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",
     "check-types": "next typegen && tsc --noEmit",
-    "test": "bun test tests/auth-providers.test.ts tests/billing-url.test.ts tests/horizontal-scroll.test.ts tests/ios-app.test.ts"
+    "test": "bun test tests/auth-providers.test.ts tests/billing-url.test.ts tests/horizontal-scroll.test.ts tests/ios-app.test.ts tests/landing-scene.test.ts"
   },
   "dependencies": {
     "@convex-dev/better-auth": "0.12.5",

--- a/apps/web/tests/horizontal-scroll.test.ts
+++ b/apps/web/tests/horizontal-scroll.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import {
   clampHorizontalOffset,
+  hashMetricsReady,
   horizontalStoryHeight,
   nearestSectionIndex,
   sectionScrollTarget,
@@ -25,6 +26,54 @@ describe("horizontal story geometry", () => {
     assert.equal(sectionScrollTarget(40, 0, 900), 40);
     assert.equal(sectionScrollTarget(40, 420, 900), 460);
     assert.equal(sectionScrollTarget(40, 1200, 900), 940);
+  });
+
+  test("waits for track overflow before treating a later section hash as ready", () => {
+    assert.equal(
+      hashMetricsReady({
+        measuredCount: 0,
+        maxTranslate: 0,
+        sectionLeft: 0,
+        isFirstSection: true,
+      }),
+      false,
+    );
+    assert.equal(
+      hashMetricsReady({
+        measuredCount: 5,
+        maxTranslate: 0,
+        sectionLeft: 0,
+        isFirstSection: false,
+      }),
+      false,
+    );
+    assert.equal(
+      hashMetricsReady({
+        measuredCount: 5,
+        maxTranslate: 4000,
+        sectionLeft: 0,
+        isFirstSection: false,
+      }),
+      false,
+    );
+    assert.equal(
+      hashMetricsReady({
+        measuredCount: 5,
+        maxTranslate: 4000,
+        sectionLeft: 0,
+        isFirstSection: true,
+      }),
+      true,
+    );
+    assert.equal(
+      hashMetricsReady({
+        measuredCount: 5,
+        maxTranslate: 4000,
+        sectionLeft: 3200,
+        isFirstSection: false,
+      }),
+      true,
+    );
   });
 
   test("selects the section nearest the viewport center", () => {

--- a/apps/web/tests/landing-scene.test.ts
+++ b/apps/web/tests/landing-scene.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  clearLandingScene,
+  peekLandingScene,
+  rememberLandingScene,
+  resetLandingSceneMemory,
+} from "../lib/landing-scene";
+
+describe("landing scene memory", () => {
+  test("survives a storage clear so a Strict Mode remount can still peek", () => {
+    resetLandingSceneMemory();
+    rememberLandingScene("start");
+    clearLandingScene("start");
+    assert.equal(peekLandingScene(), "start");
+  });
+});

--- a/apps/web/tests/landing-scene.test.ts
+++ b/apps/web/tests/landing-scene.test.ts
@@ -12,6 +12,24 @@ describe("landing scene memory", () => {
     resetLandingSceneMemory();
     rememberLandingScene("start");
     clearLandingScene("start");
-    assert.equal(peekLandingScene(), "start");
+    assert.equal(peekLandingScene(["start"]), "start");
+  });
+
+  test("ignores hashes that are not landing scenes", () => {
+    resetLandingSceneMemory();
+    rememberLandingScene("start");
+    const previous = (globalThis as { window?: Window }).window;
+    (globalThis as { window?: Window }).window = {
+      location: { hash: "#main-content" },
+    } as Window;
+    try {
+      assert.equal(peekLandingScene(["intro", "start"]), "start");
+    } finally {
+      if (previous === undefined) {
+        delete (globalThis as { window?: Window }).window;
+      } else {
+        (globalThis as { window?: Window }).window = previous;
+      }
+    }
   });
 });

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -79,8 +79,9 @@ who may attach to which session.
 
 `convex/billing.ts`:
 
-- `getState`: whether the signed-in user can open Stripe's billing portal (a
-  customer exists after Pro checkout or a later downgrade)
+- `getState`: current Free or Pro plan, and whether the signed-in user can open
+  Stripe's billing portal (a customer exists after Pro checkout or a later
+  downgrade)
 - `createProCheckout`: create a Stripe checkout URL for the Pro plan through
   Autumn, used by both the CLI upgrade hint and the web upgrade button
 - `createBillingPortal`: open Stripe's customer portal for users who already

--- a/packages/backend/convex/billing.ts
+++ b/packages/backend/convex/billing.ts
@@ -21,6 +21,7 @@ export const getState = protectedQuery({
       .first();
     return {
       canManageBilling: Boolean(row && (row.hasPro === true || row.planDowngradedAt !== undefined)),
+      plan: row?.hasPro === true ? "pro" : "free",
     };
   },
 });

--- a/packages/backend/integration-tests/billing.test.ts
+++ b/packages/backend/integration-tests/billing.test.ts
@@ -217,7 +217,10 @@ describe("billing portal visibility", () => {
   test("hides portal management until the user has a billing customer", async () => {
     const t = convexTest(schema, modules).withIdentity({ subject: "billing-user" });
 
-    await expect(t.query(api.billing.getState, {})).resolves.toEqual({ canManageBilling: false });
+    await expect(t.query(api.billing.getState, {})).resolves.toEqual({
+      canManageBilling: false,
+      plan: "free",
+    });
 
     await t.run(async (ctx) => {
       await ctx.db.insert("emailState", {
@@ -226,7 +229,10 @@ describe("billing portal visibility", () => {
       });
     });
 
-    await expect(t.query(api.billing.getState, {})).resolves.toEqual({ canManageBilling: true });
+    await expect(t.query(api.billing.getState, {})).resolves.toEqual({
+      canManageBilling: true,
+      plan: "pro",
+    });
   });
 
   test("keeps portal management after a plan downgrade", async () => {
@@ -239,7 +245,10 @@ describe("billing portal visibility", () => {
       });
     });
 
-    await expect(t.query(api.billing.getState, {})).resolves.toEqual({ canManageBilling: true });
+    await expect(t.query(api.billing.getState, {})).resolves.toEqual({
+      canManageBilling: true,
+      plan: "free",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Dashboard and footer **Install Wrapper** open the last landing scene without putting `#start` in the URL.
- Profile shows **Free** or **Pro** on the Plan row and drops redundant signed-in chrome.
- Follow-up: remember the scene across Strict Mode remounts, keep in-page `#start` pans smooth, and ignore skip-link hashes like `#main-content`.

## Test plan
- [ ] From dashboard Sessions empty state, Install Wrapper lands on the last slide (not intro); URL stays `/`
- [ ] Hero/header Install still pans smoothly to `#start`
- [ ] Footer Install on `/` (or after skip-link) still opens the last scene
- [ ] Profile Plan row shows Free or Pro and links to billing; sidebar has no plan chip
- [ ] Downgraded Pro still has Manage billing, plan reads Free

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI, landing scroll behavior, and a read-only plan field on existing billing state; no auth or payment flow changes beyond displaying plan.
> 
> **Overview**
> Dashboard and footer **Install Wrapper** links now remember the install landing scene and navigate to `/` without `#start` in the URL. The horizontal scroll controller applies that scene via session memory and a short track lock until layout and Lenis align; in-page hero/header links still use `#start` for smooth panning.
> 
> **Profile** loads billing state server-side and adds a **Plan** row (**Free** / **Pro**, linked to billing), with redundant signed-in chrome removed from the identity panel. **Billing** panels label the active plan as “Current plan,” and Convex `billing.getState` now returns `plan` alongside portal visibility.
> 
> Docs/README note profile plan and install behavior. Tests cover `landing-scene` memory, `hashMetricsReady`, and billing `getState` plan values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4177754924f9abcd3acde3e4c5866ca16614fb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->