### PR TITLE
chore(release): prepare CLI v0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The separate `apps/mobile` submodule now contains a Simulator-ready native
 iPhone/iPad viewer MVP: device authorization, owner and guest join flows,
 SwiftTerm rendering, relay transport, native WebRTC, and adaptive navigation.
 It uses Swift 6.0 language mode with complete strict concurrency on Xcode 26.
-CLI `v0.1.3` is published on GitHub Releases. Signed-device validation and App
+CLI `v0.1.4` is published on GitHub Releases. Signed-device validation and App
 Store review remain pre-release work.
 
 The active focus is operational hardening:

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "MIT",
   "bin": {

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/cli": {
       "name": "@repo/cli",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "bin": {
         "wrapper": "./index.ts",
       },


### PR DESCRIPTION
## Summary
- Lands CLI `v0.1.4` on `main` so the `Release CLI` workflow publishes GitHub Release + Homebrew tap.
- Homebrew formula now installs from the flattened archive stage (`0.1.3` `brew upgrade` failed with `ENOENT bin/wrapper`).
- CLI now surfaces **Relay sharing requires Pro** instead of a generic relay/auth failure.
- Merge branch is based on updated `origin/dev` (includes #64) with `origin/main` merged in first (already up to date).

## Test plan
- [ ] Quality gate and full lane are green
- [ ] After merge, `Release CLI` publishes `v0.1.4`
- [ ] `wrapper --version` on the published binary is `0.1.4`
- [ ] `brew upgrade wrapper` installs without `ENOENT bin/wrapper`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime or security impact in this diff.
> 
> **Overview**
> Prepares the **CLI `v0.1.4` release** by bumping `@repo/cli` from `0.1.3` to `0.1.4` in `apps/cli/package.json` and the workspace lockfile.
> 
> The **README** status section is updated so it documents `v0.1.4` as the version published on GitHub Releases, keeping repo docs aligned with what the **Release CLI** workflow will ship after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c082e9671036342a81efa8ca8e75cfe99797d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->