### PR TITLE
fix(web): align pricing cards and docs with the Free/Pro split

### DIFF
--- a/apps/docs/guides/mobile-viewer.mdx
+++ b/apps/docs/guides/mobile-viewer.mdx
@@ -29,7 +29,7 @@ The app requires iOS or iPadOS 18 or later and a shared host session.
 - a Wrapper account
 - the Wrapper CLI installed on a Mac or Linux host
 - an active wrapped shell
-- Pro relay access for remote sharing
+- Pro, to attach from another device
 
 See [Installation](/guides/installation) and
 [Authentication](/guides/auth) before continuing.

--- a/apps/docs/guides/remote-share.mdx
+++ b/apps/docs/guides/remote-share.mdx
@@ -82,7 +82,7 @@ Details: [Security and privacy](/configuration/security).
 
 ## Upgrade to Pro
 
-Pro is $20 per month and unlocks relay sharing. Upgrade from the web onboarding
-flow at [wrapper.sh](https://wrapper.sh) after sign-in.
+Pro is $20 per month and unlocks attach from another device. Upgrade from
+[dashboard billing](https://www.wrapper.sh/dashboard/billing) after sign-in.
 
 See [Pricing](/reference/pricing).

--- a/apps/docs/introduction.mdx
+++ b/apps/docs/introduction.mdx
@@ -16,7 +16,7 @@ choose.
 - Local attach joins that live PTY over loopback with a per-session token.
 - Remote share (Pro) routes through an authenticated Fly.io relay, with a
   default WebRTC P2P fast path for lower latency.
-- Free covers local wrapping. Pro unlocks relay sharing.
+- Free: attach from the same computer. Pro: attach from another device.
 
 ## Prerequisites
 

--- a/apps/docs/reference/pricing.mdx
+++ b/apps/docs/reference/pricing.mdx
@@ -5,10 +5,10 @@ description: "Local is free. Remote is Pro."
 
 ## Plans
 
-| Plan | Price       | Includes                                                                 |
-| ---- | ----------- | ------------------------------------------------------------------------ |
+| Plan | Price       | Includes                                                                                |
+| ---- | ----------- | --------------------------------------------------------------------------------------- |
 | Free | $0          | Wrap zsh, bash, and fish. Attach from the same computer. Sessions stay on your machine. |
-| Pro  | $20 / month | Everything in Free. Attach from another device. Share a session, revoke anytime. |
+| Pro  | $20 / month | Everything in Free. Attach from another device. Share a session, revoke anytime.        |
 
 Upgrade from signed-in [dashboard billing](https://www.wrapper.sh/dashboard/billing).
 Profile shows Free or Pro. Stripe's customer portal is available after the

--- a/apps/docs/reference/pricing.mdx
+++ b/apps/docs/reference/pricing.mdx
@@ -1,26 +1,36 @@
 ---
 title: "Pricing"
-description: "Free local wrapping and Pro remote sharing."
+description: "Local is free. Remote is Pro."
 ---
 
 ## Plans
 
-| Plan | Price       | Includes                                   |
-| ---- | ----------- | ------------------------------------------ |
-| Free | $0          | Shell wrapping, local attach, account auth |
-| Pro  | $20 / month | Remote relay sharing (`can_share_relay`)   |
+| Plan | Price       | Includes                                                                 |
+| ---- | ----------- | ------------------------------------------------------------------------ |
+| Free | $0          | Wrap zsh, bash, and fish. Attach from the same computer. Sessions stay on your machine. |
+| Pro  | $20 / month | Everything in Free. Attach from another device. Share a session, revoke anytime. |
 
-Upgrade from the signed-in [dashboard billing](https://www.wrapper.sh/dashboard/billing)
-page. Profile shows Free or Pro. Stripe's customer portal is available after
-the first Pro checkout; free accounts only see upgrade.
+Upgrade from signed-in [dashboard billing](https://www.wrapper.sh/dashboard/billing).
+Profile shows Free or Pro. Stripe's customer portal is available after the
+first Pro checkout; free accounts only see upgrade.
 
-## What Pro unlocks
+## Free
 
-- Host can press `Ctrl+\` then `s` to share
-- Viewers can `wrapper attach --relay --id <sessionId>`
-- Default WebRTC P2P fast path with relay fallback
+- Wrap `zsh`, `bash`, and `fish`
+- Attach from another terminal on the same computer
+- Sessions stay on your machine (loopback, no relay)
 
-Without Pro, local wrapping and local attach remain available.
+Released binaries still require `wrapper auth login` as the session owner.
+Local attach does not require Pro.
+
+## Pro
+
+- Everything in Free
+- Attach from another device
+- Share a session from the host (`Ctrl+\` then `s`), revoke anytime (`Ctrl+\` then `u`)
+- iOS viewer for iPhone and iPad
+
+How a remote session connects is in [Remote share](/guides/remote-share).
 
 ## Entitlement id
 
@@ -31,4 +41,5 @@ deployment.
 ## Related
 
 - [Remote share](/guides/remote-share)
+- [Mobile viewer](/guides/mobile-viewer)
 - [Security and privacy](/configuration/security)

--- a/apps/docs/troubleshooting.mdx
+++ b/apps/docs/troubleshooting.mdx
@@ -56,8 +56,8 @@ same machine is not enough if you are not the authenticated owner.
 
 ## Relay share says Pro is required
 
-Upgrade to Pro to enable remote sharing. Local attach remains available without
-Pro. See [Pricing](/reference/pricing).
+Upgrade to Pro to attach from another device. Attach from the same computer
+remains available without Pro. See [Pricing](/reference/pricing).
 
 ## P2P does not come up
 

--- a/apps/web/app/dashboard/billing/page.tsx
+++ b/apps/web/app/dashboard/billing/page.tsx
@@ -43,9 +43,9 @@ export default async function DashboardBillingPage({
             <strong className="dashboardPlanPrice">$0</strong>
           </div>
           <ul className="dashboardFeatureList">
-            <li>Local wrap for zsh, bash, and fish</li>
-            <li>Attach from this computer</li>
-            <li>No subscription required</li>
+            <li>Wrap zsh, bash, and fish</li>
+            <li>Attach from the same computer</li>
+            <li>Sessions stay on your machine</li>
           </ul>
         </article>
 
@@ -63,9 +63,9 @@ export default async function DashboardBillingPage({
             </p>
           </div>
           <ul className="dashboardFeatureList">
+            <li>Everything in Free</li>
             <li>Attach from another device</li>
-            <li>WebRTC when available</li>
-            <li>Authenticated relay fallback</li>
+            <li>Share a session, revoke anytime</li>
           </ul>
         </article>
       </div>

--- a/apps/web/components/horizontal-landing.tsx
+++ b/apps/web/components/horizontal-landing.tsx
@@ -183,11 +183,9 @@ export function HorizontalLanding() {
                   </p>
                 </header>
                 <ul>
-                  <li>Wrapper for zsh, bash, and fish</li>
+                  <li>Wrap zsh, bash, and fish</li>
                   <li>Attach from the same computer</li>
-                  <li>Share and revoke controls</li>
-                  <li>Per-session secure tokens</li>
-                  <li>No account required</li>
+                  <li>Sessions stay on your machine</li>
                 </ul>
                 <a className="landingPriceCta" href="#start">
                   Install Wrapper
@@ -208,10 +206,9 @@ export function HorizontalLanding() {
                   </p>
                 </header>
                 <ul>
-                  <li>Everything included in Free</li>
+                  <li>Everything in Free</li>
                   <li>Attach from another device</li>
-                  <li>Direct WebRTC when available</li>
-                  <li>Authenticated relay fallback</li>
+                  <li>Share a session, revoke anytime</li>
                   <li>
                     <IosViewerCta variant="text" />
                   </li>


### PR DESCRIPTION
## Summary
- Landing and dashboard billing cards now state the same Free/Pro split: wrap + attach from the same computer vs attach from another device and share/revoke.
- Removed incorrect Free claims (share/revoke, no account, no subscription) and Pro transport filler (WebRTC/relay).
- Docs pricing, intro, remote share, mobile viewer, and troubleshooting match that language.

## Test plan
- [ ] Landing `/#pricing` Free/Pro lists match dashboard `/dashboard/billing`
- [ ] Docs `/reference/pricing` table matches those cards
- [ ] No remaining “no account required” or “share and revoke” on Free

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and marketing copy only; no billing logic, entitlements, or runtime behavior changes.
> 
> **Overview**
> **Aligns Free vs Pro messaging** across the landing page, dashboard billing, and docs so they describe the same product split: **Free** is wrap + attach on the same machine; **Pro** is attach from another device plus share/revoke (and iOS viewer in docs).
> 
> Copy updates replace older “relay sharing” / transport wording with user-facing “attach from another device” language, and **drop inaccurate Free bullets** (e.g. share/revoke, no account). **Pro cards no longer list WebRTC/relay** as plan features. The **pricing reference** is restructured into explicit Free and Pro sections with an updated table and a link to the mobile viewer guide.
> 
> **Upgrade CTAs** in docs now point to **dashboard billing** instead of generic web onboarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e1bf830d7fd154a02bfe844156a365c1c7b6ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->