### PR TITLE
fix(web): show Autumn plan and Stripe return moments

### DIFF
--- a/apps/web/app/dashboard/billing/billing-client.tsx
+++ b/apps/web/app/dashboard/billing/billing-client.tsx
@@ -19,9 +19,11 @@ const checkoutRef = makeFunctionReference<
 
 export function DashboardBillingActions({
   token,
+  plan,
   canManageBilling,
 }: {
   token: string;
+  plan: "free" | "pro";
   canManageBilling: boolean;
 }) {
   const [pending, setPending] = useState<"portal" | "checkout" | null>(null);
@@ -40,7 +42,7 @@ export function DashboardBillingActions({
     setPending("portal");
     setError(null);
     try {
-      const returnUrl = new URL("/dashboard/billing", window.location.origin).toString();
+      const returnUrl = new URL("/plan/returned", window.location.origin).toString();
       const result = await client.action(billingPortalRef, { returnUrl });
       const portalUrl = getSafeBillingPortalUrl(result.portalUrl);
       if (!portalUrl) throw new Error("Unexpected billing portal address.");
@@ -58,10 +60,7 @@ export function DashboardBillingActions({
     setPending("checkout");
     setError(null);
     try {
-      const successUrl = new URL(
-        "/dashboard/billing?upgraded=1",
-        window.location.origin,
-      ).toString();
+      const successUrl = new URL("/plan/upgraded", window.location.origin).toString();
       const result = await client.action(checkoutRef, { successUrl });
       const checkoutUrl = getSafeCheckoutUrl(result.checkoutUrl);
       if (!checkoutUrl) throw new Error("Unexpected checkout address.");
@@ -79,20 +78,24 @@ export function DashboardBillingActions({
       <div>
         <h2 id="billing-actions-title">Billing actions</h2>
         <p>
-          {canManageBilling
-            ? "Use Stripe for subscription management or start a new Pro checkout."
+          {plan === "pro"
+            ? canManageBilling
+              ? "Use Stripe to manage invoices, payment details, and cancellation."
+              : "You're on Pro. A paid checkout is what creates a Stripe portal for invoices."
             : "Upgrade to Pro when a session needs to leave this machine."}
         </p>
       </div>
       <div className="authActions">
-        <button
-          type="button"
-          className="social-btn social-btn-primary"
-          disabled={pending !== null}
-          onClick={() => void startCheckout()}
-        >
-          {pending === "checkout" ? "Starting checkout…" : "Upgrade to Pro"}
-        </button>
+        {plan === "free" ? (
+          <button
+            type="button"
+            className="social-btn social-btn-primary"
+            disabled={pending !== null}
+            onClick={() => void startCheckout()}
+          >
+            {pending === "checkout" ? "Starting checkout…" : "Upgrade to Pro"}
+          </button>
+        ) : null}
         {canManageBilling ? (
           <button
             type="button"

--- a/apps/web/app/dashboard/billing/page.tsx
+++ b/apps/web/app/dashboard/billing/page.tsx
@@ -70,7 +70,7 @@ export default async function DashboardBillingPage({
         </article>
       </div>
 
-      <DashboardBillingActions token={token} canManageBilling={canManageBilling} />
+      <DashboardBillingActions token={token} plan={plan} canManageBilling={canManageBilling} />
 
       {canManageBilling ? (
         <aside className="dashboardNotice">

--- a/apps/web/app/plan/cancelled/page.tsx
+++ b/apps/web/app/plan/cancelled/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { PlanMoment } from "../../../components/plan-moment";
+
+export const metadata: Metadata = {
+  title: "Back on Free",
+  description: "Wrapper Pro has been cancelled on this account.",
+  robots: { index: false, follow: false },
+};
+
+export default function PlanCancelledPage() {
+  return <PlanMoment variant="cancelled" />;
+}

--- a/apps/web/app/plan/layout.tsx
+++ b/apps/web/app/plan/layout.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+import { AuthShell } from "../../components/auth-shell";
+import { SiteHeader } from "../../components/landing-header";
+import { getAuthProviderAvailability } from "../../lib/auth-providers";
+import { getToken, isAuthenticated } from "../../lib/auth-server";
+import { DashboardSignIn } from "../dashboard/dashboard-sign-in";
+
+export default async function PlanLayout({ children }: { children: ReactNode }) {
+  const [authenticated, token] = await Promise.all([isAuthenticated(), getToken()]);
+  const signedIn = authenticated && Boolean(token);
+  const providers = getAuthProviderAvailability(process.env);
+
+  if (!signedIn) {
+    return (
+      <AuthShell
+        title="Sign in"
+        description="Continue with the account on your Wrapper profile."
+        size="narrow"
+        showHeaderAction={false}
+        showFooter={false}
+      >
+        <DashboardSignIn appleEnabled={providers.apple} />
+      </AuthShell>
+    );
+  }
+
+  return (
+    <div className="dashboardShell">
+      <SiteHeader showAction={false} />
+      <main id="main-content" className="planMoment" tabIndex={-1}>
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/apps/web/app/plan/returned/page.tsx
+++ b/apps/web/app/plan/returned/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from "next/navigation";
+import { getToken } from "../../../lib/auth-server";
+import { getDashboardBillingState } from "../../../lib/dashboard-server";
+
+export default async function PlanReturnedPage() {
+  const token = await getToken();
+  if (!token) return null;
+
+  const billing = await getDashboardBillingState(token);
+  if (billing?.plan === "free") redirect("/plan/cancelled");
+  redirect("/dashboard/billing");
+}

--- a/apps/web/app/plan/upgraded/page.tsx
+++ b/apps/web/app/plan/upgraded/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { PlanMoment } from "../../../components/plan-moment";
+
+export const metadata: Metadata = {
+  title: "Pro unlocked",
+  description: "Wrapper Pro is active on this account.",
+  robots: { index: false, follow: false },
+};
+
+export default function PlanUpgradedPage() {
+  return <PlanMoment variant="upgraded" />;
+}

--- a/apps/web/app/surfaces.css
+++ b/apps/web/app/surfaces.css
@@ -618,6 +618,104 @@
   border-color: color-mix(in srgb, var(--color-accent-pop) 28%, var(--color-border));
 }
 
+.planMoment {
+  display: grid;
+  flex: 1;
+  place-items: center;
+  width: min(100%, var(--content-max));
+  margin: 0 auto;
+  padding: clamp(48px, 12vh, 120px) var(--page-pad) 80px;
+}
+
+.planMomentCard {
+  display: grid;
+  justify-items: center;
+  gap: 32px;
+  max-width: 440px;
+  text-align: center;
+}
+
+.planMomentMark {
+  width: 120px;
+  height: 120px;
+}
+
+.planMomentSvg {
+  display: block;
+  width: 120px;
+  height: 120px;
+}
+
+.planMomentRing,
+.planMomentStroke {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.planMomentRing {
+  stroke: color-mix(in srgb, var(--color-accent-pop) 28%, var(--color-border));
+  stroke-width: 2;
+}
+
+.planMomentCard[data-variant="cancelled"] .planMomentRing {
+  stroke: var(--color-border);
+}
+
+.planMomentStroke {
+  stroke: var(--color-accent-pop);
+  stroke-width: 4;
+  stroke-dasharray: 52;
+  stroke-dashoffset: 52;
+  animation: planMomentDraw 500ms var(--ease-out-quint) 80ms forwards;
+}
+
+.planMomentCard[data-variant="cancelled"] .planMomentStroke {
+  stroke: var(--color-text-muted);
+  stroke-dasharray: 36;
+  stroke-dashoffset: 36;
+}
+
+.planMomentCopy {
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  animation: riseIn 640ms var(--ease-out-quint) 80ms both;
+}
+
+.planMomentCopy .dashboardPanelLabel {
+  margin-bottom: 0;
+}
+
+.planMomentCopy h1 {
+  font-size: clamp(1.85rem, 4vw, 2.4rem);
+  font-weight: 590;
+  line-height: 1.08;
+  letter-spacing: -0.05em;
+}
+
+.planMomentCopy p:not(.dashboardPanelLabel) {
+  max-width: 38ch;
+  color: var(--color-text-muted);
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.planMomentActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  animation: riseIn 640ms var(--ease-out-quint) 160ms both;
+}
+
+@keyframes planMomentDraw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
 .dashboardPlanPrice {
   display: flex;
   flex-direction: column;

--- a/apps/web/components/plan-moment.tsx
+++ b/apps/web/components/plan-moment.tsx
@@ -14,8 +14,8 @@ export function PlanMoment({ variant }: { variant: "upgraded" | "cancelled" }) {
             <p className="dashboardPanelLabel">Pro</p>
             <h1 id="plan-moment-title">You unlocked remote sessions</h1>
             <p>
-              Attach from another device and share a wrapped shell. The session still starts on
-              your machine; Pro is what lets it leave.
+              Attach from another device and share a wrapped shell. The session still starts on your
+              machine; Pro is what lets it leave.
             </p>
           </>
         ) : (

--- a/apps/web/components/plan-moment.tsx
+++ b/apps/web/components/plan-moment.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+
+export function PlanMoment({ variant }: { variant: "upgraded" | "cancelled" }) {
+  const upgraded = variant === "upgraded";
+
+  return (
+    <section className="planMomentCard" data-variant={variant} aria-labelledby="plan-moment-title">
+      <div className="planMomentMark" aria-hidden="true">
+        {upgraded ? <UpgradedMark /> : <CancelledMark />}
+      </div>
+      <div className="planMomentCopy">
+        {upgraded ? (
+          <>
+            <p className="dashboardPanelLabel">Pro</p>
+            <h1 id="plan-moment-title">You unlocked remote sessions</h1>
+            <p>
+              Attach from another device and share a wrapped shell. The session still starts on
+              your machine; Pro is what lets it leave.
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="dashboardPanelLabel">Free</p>
+            <h1 id="plan-moment-title">Back on this machine</h1>
+            <p>
+              Local wrapping stays. Remote attach and sharing pause until you upgrade again. Nothing
+              else in your profile changes.
+            </p>
+          </>
+        )}
+      </div>
+      <div className="planMomentActions">
+        {upgraded ? (
+          <>
+            <Link className="primaryAction" href="/dashboard/sessions">
+              View sessions
+            </Link>
+            <Link className="textAction" href="/dashboard/billing">
+              Billing
+            </Link>
+          </>
+        ) : (
+          <>
+            <Link className="primaryAction" href="/dashboard/billing">
+              Back to billing
+            </Link>
+            <Link className="textAction" href="/dashboard/sessions">
+              View sessions
+            </Link>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function UpgradedMark() {
+  return (
+    <svg className="planMomentSvg" viewBox="0 0 120 120" fill="none">
+      <circle className="planMomentRing" cx="60" cy="60" r="36" />
+      <path className="planMomentStroke" d="M44 61.5 54.5 72 77 47" />
+    </svg>
+  );
+}
+
+function CancelledMark() {
+  return (
+    <svg className="planMomentSvg" viewBox="0 0 120 120" fill="none">
+      <circle className="planMomentRing" cx="60" cy="60" r="36" />
+      <path className="planMomentStroke" d="M42 60h36" />
+    </svg>
+  );
+}

--- a/apps/web/lib/dashboard-server.ts
+++ b/apps/web/lib/dashboard-server.ts
@@ -34,10 +34,10 @@ const onboardingStateRef = makeFunctionReference<
 >("onboarding:getState");
 
 const billingStateRef = makeFunctionReference<
-  "query",
+  "action",
   Record<string, never>,
   DashboardBillingState
->("billing:getState");
+>("billing:getLiveState");
 
 const activeSessionsRef = makeFunctionReference<"query", Record<string, never>, DashboardSession[]>(
   "session:listActive",
@@ -69,7 +69,7 @@ export async function getDashboardBillingState(
   client.setAuth(token);
 
   try {
-    return await client.query(billingStateRef, {});
+    return await client.action(billingStateRef, {});
   } catch {
     return null;
   }

--- a/packages/backend/convex/billing.ts
+++ b/packages/backend/convex/billing.ts
@@ -1,3 +1,4 @@
+import { makeFunctionReference } from "convex/server";
 import { v } from "convex/values";
 import { createError, ErrorCode } from "./lib/errors.ts";
 import { protectedAction, protectedQuery } from "./lib/middleware.ts";
@@ -11,6 +12,15 @@ const appOrigin = new URL(
 ).origin;
 const STRIPE_CHECKOUT_ORIGIN = "https://checkout.stripe.com";
 const STRIPE_PORTAL_ORIGIN = "https://billing.stripe.com";
+
+type BillingState = {
+  canManageBilling: boolean;
+  plan: "free" | "pro";
+};
+
+const getCachedStateRef = makeFunctionReference<"query", Record<string, never>, BillingState>(
+  "billing:getState",
+);
 
 export const getState = protectedQuery({
   args: {},
@@ -26,10 +36,41 @@ export const getState = protectedQuery({
   },
 });
 
+/**
+ * Dashboard plan from Autumn (same source as relay share), with the webhook
+ * `emailState` row as fallback when the provider is down. Portal eligibility
+ * still comes from that row: a Stripe customer exists after paid checkout, not
+ * after an Autumn dashboard grant.
+ */
+export const getLiveState = protectedAction({
+  args: {},
+  handler: async (ctx): Promise<BillingState> => {
+    const cached = await ctx.runQuery(getCachedStateRef, {});
+    const featureId = getRelayShareFeatureId();
+    if (!featureId) return cached;
+
+    const access = await ctx.autumn.check(ctx, { featureId });
+    if (access.error) return cached;
+    return {
+      canManageBilling: cached.canManageBilling,
+      plan: access.data?.allowed === true ? "pro" : "free",
+    };
+  },
+});
+
 function getProPlanId(): string {
   const value = process.env.WRAPPER_AUTUMN_PRO_PLAN_ID;
   if (!value) return "pro";
   return value.trim();
+}
+
+function getRelayShareFeatureId(): string | null {
+  const value = process.env.WRAPPER_AUTUMN_RELAY_SHARE_FEATURE_ID;
+  if (value === undefined) return "can_share_relay";
+  const trimmed = value.trim();
+  const disabled = ["", "off", "none", "false", "0", "disabled"];
+  if (disabled.includes(trimmed.toLowerCase())) return null;
+  return trimmed;
 }
 
 /**

--- a/packages/backend/integration-tests/billing.test.ts
+++ b/packages/backend/integration-tests/billing.test.ts
@@ -252,6 +252,39 @@ describe("billing portal visibility", () => {
   });
 });
 
+describe("live billing state", () => {
+  test("reads the current plan from Autumn instead of the webhook cache", async () => {
+    vi.spyOn(Autumn.prototype, "check").mockResolvedValue({
+      data: { allowed: true },
+      error: null,
+    } as never);
+    const t = convexTest(schema, modules).withIdentity({ subject: "granted-user" });
+
+    await expect(t.action(api.billing.getLiveState, {})).resolves.toEqual({
+      canManageBilling: false,
+      plan: "pro",
+    });
+  });
+
+  test("falls back to the webhook cache when Autumn is unavailable", async () => {
+    vi.spyOn(Autumn.prototype, "check").mockResolvedValue({
+      error: { message: "down" },
+    } as never);
+    const t = convexTest(schema, modules).withIdentity({ subject: "cached-pro" });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("emailState", {
+        userId: "cached-pro",
+        hasPro: true,
+      });
+    });
+
+    await expect(t.action(api.billing.getLiveState, {})).resolves.toEqual({
+      canManageBilling: true,
+      plan: "pro",
+    });
+  });
+});
+
 describe("billing account cleanup", () => {
   test("queues provider work without contacting billing during account deletion", async () => {
     vi.useFakeTimers();


### PR DESCRIPTION
## Summary
- Dashboard plan now reads Autumn (`billing:getLiveState`) instead of the webhook cache, so localhost grants show Pro.
- Hide Upgrade when already Pro; show Manage billing only when a Stripe customer exists.
- Checkout and portal returns land on a focused header-only `/plan/*` interstitial instead of bouncing straight back into the dashboard.

## Test plan
- [ ] Free account: billing shows Upgrade; after checkout success, `/plan/upgraded` then dashboard shows Pro
- [ ] Autumn dashboard grant (no Stripe): plan is Pro, Upgrade is hidden, Manage billing is hidden
- [ ] Paid Pro with Stripe customer: Manage billing opens the portal; return to `/plan/returned` then billing (or `/plan/cancelled` if now Free)
- [ ] Quality gate and Full lane green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Billing UI and plan detection now depend on Autumn at runtime (with cache fallback); incorrect feature config or provider outages could show stale plan until fallback kicks in.
> 
> **Overview**
> Dashboard **plan** now comes from **`billing:getLiveState`** (Autumn `check` on the relay-share feature), with webhook **`emailState`** as fallback when Autumn fails; **Stripe portal eligibility** (`canManageBilling`) is unchanged and still tied to paid checkout history in that cache.
> 
> Billing actions are **plan-aware**: **Upgrade to Pro** only on Free, copy distinguishes Pro-without-Stripe vs paid Pro, and Stripe **checkout success** / **portal return** URLs point to **`/plan/upgraded`** and **`/plan/returned`** instead of dashboard query params.
> 
> New **`/plan`** routes add a signed-in, header-only **interstitial** (`PlanMoment` + styles): celebrate upgrade, show cancellation when **`/plan/returned`** sees Free, otherwise redirect back to billing. Integration tests cover live state and Autumn fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27125558d2170336acc296e471dbaf55d6d5035f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->