### PR TITLE
fix(cli): show sharing progress so prefix+s is not spammed

### DIFF
--- a/apps/cli/commands/shell-host.ts
+++ b/apps/cli/commands/shell-host.ts
@@ -303,6 +303,7 @@ export async function runShellHost(opts: ShellHostOptions = {}): Promise<void> {
   heartbeat.unref();
 
   function currentTransport(): SessionTransportStatus {
+    if (relayStarting && !shared) return "sharing";
     if (!shared) return "local";
     if (relayStarting) return "connecting";
     if (!relayBridge) return "local";
@@ -341,114 +342,117 @@ export async function runShellHost(opts: ShellHostOptions = {}): Promise<void> {
   }
 
   const startRelayBridge = async (): Promise<void> => {
-    if (relayBridge || relayStarting) return;
-
-    if (backend.status !== "ready") {
-      // Local-only share (no relay); allowed without a Pro plan.
-      commitShared();
-      announce(
-        `wrapper • shared • ${sessionTag}`,
-        "session shared locally (relay unavailable: login/backend required)",
-      );
-      return;
-    }
-
-    relayStarting = true;
-    paintRestingTitle();
-    const code = generateShareCode();
+    // `relayStarting` is flipped by the share command before this runs, so a
+    // second prefix+s cannot race the in-flight setup. Always clear it here.
     try {
-      // Persist the shared flag and the access-code hash before issuing the relay
-      // ticket so viewer authorization is synchronized rather than racing the
-      // periodic fire-and-forget heartbeat. Only the code hash is stored.
-      await backend.client.mutation(setShareCodeRef, { sessionId, code });
-      await backend.client.mutation(setRelayStateRef, { sessionId, relayState: "connecting" });
-      const issued = await backend.client.action(issueHostRelayTicketRef, { sessionId });
-      relayBridge = startRelayHostBridge({
-        relayUrl: env.relayUrl,
-        ticket: issued.ticket,
-        sessionId,
-        pty: session,
-        enableP2P: env.p2pEnabled,
-        onTransportChange: (state) => {
-          relayConnected = state.relayConnected;
-          p2pPeerCount = state.p2pPeerCount;
-          paintRestingTitle();
-        },
-        onOpen: () => {
-          if (backend.status !== "ready") return;
-          void backend.client
-            .mutation(setRelayStateRef, { sessionId, relayState: "online" })
-            .catch(() => {});
-        },
-        onClose: () => {
-          if (backend.status !== "ready") return;
-          void backend.client
-            .mutation(setRelayStateRef, { sessionId, relayState: "offline" })
-            .catch(() => {});
-        },
-        onError: () => {
-          if (backend.status !== "ready") return;
-          void backend.client
-            .mutation(setRelayStateRef, { sessionId, relayState: "error" })
-            .catch(() => {});
-        },
-      });
-      shareCode = code;
-      commitShared();
-      announce(`wrapper • shared • ${sessionTag}`, "session shared via relay");
-      printShareInvite();
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      const payload = convexErrorPayload(error);
-      await backend.client
-        .mutation(setRelayStateRef, { sessionId, relayState: "error" })
-        .catch(() => {});
+      if (relayBridge) return;
 
-      if (isProPlanRequiredError(error)) {
-        // Expected outcome for free users. `shared` is never committed until a
-        // share succeeds, so nothing to roll back locally — just undo the backend
-        // heartbeat we sent before the ticket, and show a clean upgrade prompt
-        // (with a retry hint) instead of dumping the raw server error.
-        log.debug("relay share denied (Pro required)", {
+      if (backend.status !== "ready") {
+        // Local-only share (no relay); allowed without a Pro plan.
+        commitShared();
+        announce(
+          `wrapper • shared • ${sessionTag}`,
+          "session shared locally (relay unavailable: login/backend required)",
+        );
+        return;
+      }
+
+      paintRestingTitle();
+      const code = generateShareCode();
+      try {
+        // Persist the shared flag and the access-code hash before issuing the relay
+        // ticket so viewer authorization is synchronized rather than racing the
+        // periodic fire-and-forget heartbeat. Only the code hash is stored.
+        await backend.client.mutation(setShareCodeRef, { sessionId, code });
+        await backend.client.mutation(setRelayStateRef, { sessionId, relayState: "connecting" });
+        const issued = await backend.client.action(issueHostRelayTicketRef, { sessionId });
+        relayBridge = startRelayHostBridge({
+          relayUrl: env.relayUrl,
+          ticket: issued.ticket,
+          sessionId,
+          pty: session,
+          enableP2P: env.p2pEnabled,
+          onTransportChange: (state) => {
+            relayConnected = state.relayConnected;
+            p2pPeerCount = state.p2pPeerCount;
+            paintRestingTitle();
+          },
+          onOpen: () => {
+            if (backend.status !== "ready") return;
+            void backend.client
+              .mutation(setRelayStateRef, { sessionId, relayState: "online" })
+              .catch(() => {});
+          },
+          onClose: () => {
+            if (backend.status !== "ready") return;
+            void backend.client
+              .mutation(setRelayStateRef, { sessionId, relayState: "offline" })
+              .catch(() => {});
+          },
+          onError: () => {
+            if (backend.status !== "ready") return;
+            void backend.client
+              .mutation(setRelayStateRef, { sessionId, relayState: "error" })
+              .catch(() => {});
+          },
+        });
+        shareCode = code;
+        commitShared();
+        announce(`wrapper • shared • ${sessionTag}`, "session shared via relay");
+        printShareInvite();
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        const payload = convexErrorPayload(error);
+        await backend.client
+          .mutation(setRelayStateRef, { sessionId, relayState: "error" })
+          .catch(() => {});
+
+        if (isProPlanRequiredError(error)) {
+          // Expected outcome for free users. `shared` is never committed until a
+          // share succeeds, so nothing to roll back locally — just undo the backend
+          // heartbeat we sent before the ticket, and show a clean upgrade prompt
+          // (with a retry hint) instead of dumping the raw server error.
+          log.debug("relay share denied (Pro required)", {
+            error: err.message,
+            code: payload.code,
+            detail: payload.message,
+          });
+          await backend.client.mutation(setShareCodeRef, { sessionId }).catch(() => {});
+          if (env.hudEnabled) setTitle("");
+
+          const checkoutUrl = await fetchProCheckoutUrl(backend.client);
+          const lines = checkoutUrl
+            ? [
+                "Relay sharing requires Pro.",
+                `Upgrade → ${checkoutUrl}`,
+                `Once upgraded, press ${prefix.label} then s to share (no restart needed).`,
+              ]
+            : [
+                "Relay sharing requires Pro — upgrade your plan,",
+                `then press ${prefix.label} then s to try again.`,
+              ];
+          if (session.isIdle) {
+            for (const line of lines) inlineMessage(line);
+          } else {
+            for (const line of lines) log.info(line);
+          }
+          if (env.hudEnabled) notifyOS("wrapper", "Relay sharing requires Pro");
+          return;
+        }
+
+        // Unexpected failure (e.g. relay unreachable): keep the diagnostic warning
+        // and fall back to a local-only share.
+        log.warn("failed to start relay bridge", {
           error: err.message,
           code: payload.code,
           detail: payload.message,
         });
-        await backend.client.mutation(setShareCodeRef, { sessionId }).catch(() => {});
-        if (env.hudEnabled) setTitle("");
-
-        const checkoutUrl = await fetchProCheckoutUrl(backend.client);
-        const lines = checkoutUrl
-          ? [
-              "Relay sharing requires Pro.",
-              `Upgrade → ${checkoutUrl}`,
-              `Once upgraded, press ${prefix.label} then s to share (no restart needed).`,
-            ]
-          : [
-              "Relay sharing requires Pro — upgrade your plan,",
-              `then press ${prefix.label} then s to try again.`,
-            ];
-        if (session.isIdle) {
-          for (const line of lines) inlineMessage(line);
-        } else {
-          for (const line of lines) log.info(line);
-        }
-        if (env.hudEnabled) notifyOS("wrapper", "Relay sharing requires Pro");
-        return;
+        commitShared();
+        announce(
+          `wrapper • shared • ${sessionTag}`,
+          "session shared locally (relay connect failed; check logs/auth)",
+        );
       }
-
-      // Unexpected failure (e.g. relay unreachable): keep the diagnostic warning
-      // and fall back to a local-only share.
-      log.warn("failed to start relay bridge", {
-        error: err.message,
-        code: payload.code,
-        detail: payload.message,
-      });
-      commitShared();
-      announce(
-        `wrapper • shared • ${sessionTag}`,
-        "session shared locally (relay connect failed; check logs/auth)",
-      );
     } finally {
       relayStarting = false;
       paintRestingTitle();
@@ -477,12 +481,24 @@ export async function runShellHost(opts: ShellHostOptions = {}): Promise<void> {
           announce(`wrapper • shared • ${sessionTag}`, "already shared");
           return;
         }
+        if (relayStarting) {
+          announce(`wrapper • sharing • ${sessionTag}`, "already sharing…");
+          return;
+        }
         // `shared` is committed inside startRelayBridge only once the share
         // actually takes effect, so a denied relay share (e.g. no Pro plan)
-        // never leaves the session marked as shared.
+        // never leaves the session marked as shared. Flip `relayStarting`
+        // synchronously so a second prefix+s cannot race the in-flight setup.
+        relayStarting = true;
+        paintRestingTitle();
+        announce(`wrapper • sharing • ${sessionTag}`, "sharing…");
         void startRelayBridge();
         break;
       case "unshare":
+        if (relayStarting) {
+          announce(`wrapper • sharing • ${sessionTag}`, "still sharing…");
+          return;
+        }
         if (!shared) {
           announce("", "not currently shared");
           return;
@@ -504,7 +520,7 @@ export async function runShellHost(opts: ShellHostOptions = {}): Promise<void> {
       case "status":
         announce(
           shared ? `wrapper • shared • ${sessionTag}` : `wrapper • idle • ${sessionTag}`,
-          `id=${sessionTag} port=${server.port} shared=${shared ? "yes" : "no"}`,
+          `id=${sessionTag} port=${server.port} shared=${shared ? "yes" : relayStarting ? "sharing" : "no"} transport=${currentTransport()}`,
         );
         break;
       case "detach":

--- a/apps/cli/tests/feedback.test.ts
+++ b/apps/cli/tests/feedback.test.ts
@@ -24,6 +24,16 @@ describe("session HUD", () => {
     ).toBe("● host • ABC123 • p2p x2 | s share • u unshare • ? status");
   });
 
+  test("formats sharing transport while share is in flight", () => {
+    expect(
+      formatSessionHud({
+        role: "host",
+        sessionTag: "ABC123",
+        transport: "sharing",
+      }),
+    ).toBe("wrapper • host • ABC123 • sharing");
+  });
+
   test("formats viewer prefix controls", () => {
     expect(
       formatSessionHud({

--- a/apps/cli/util/feedback.ts
+++ b/apps/cli/util/feedback.ts
@@ -37,7 +37,13 @@ const ESC = "\x1b";
 const BEL = "\x07";
 
 export type SessionHudRole = "host" | "viewer";
-export type SessionTransportStatus = "local" | "connecting" | "relay" | "p2p" | "offline";
+export type SessionTransportStatus =
+  | "local"
+  | "sharing"
+  | "connecting"
+  | "relay"
+  | "p2p"
+  | "offline";
 
 export interface SessionHudState {
   role: SessionHudRole;


### PR DESCRIPTION
## Summary
- Prefix+s now prints `sharing…` immediately and marks the HUD as `sharing` before the relay round-trip, so the shortcut is not silent (and not spam-clicked).
- Repeat share while in flight says `already sharing…`; unshare during that window says `still sharing…` instead of `not currently shared`.
- Status includes `transport=` so the same HUD path is visible from `?`.

## Test plan
- [x] `bun test ./apps/cli/tests/feedback.test.ts`
- [ ] Wrapped idle shell: prefix+s → `[wrapper] sharing…`, then share code / shared message
- [ ] Spam prefix+s during the round-trip → `already sharing…`, one share
- [ ] Prefix+u during sharing → `still sharing…`; after success, prefix+u → `session unshared`
- [ ] Prefix+? during sharing → `shared=sharing transport=sharing`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX and concurrency guard around session sharing only; relay/share semantics are unchanged aside from clearer in-flight state.
> 
> **Overview**
> **Prefix+s** now gives immediate feedback while relay setup runs: `relayStarting` is set synchronously in the share handler (not inside the async bridge startup), the HUD/title show transport **`sharing`**, and users see **`sharing…`** right away.
> 
> Repeat **share** during that window responds with **`already sharing…`** instead of starting a second setup; **unshare** during the same window says **`still sharing…`**. The **status** command reports `shared=sharing` and `transport=sharing` so in-flight state matches the title bar.
> 
> `startRelayBridge` was refactored so it no longer toggles `relayStarting` at entry—only clears it in `finally`—and adds a new **`sharing`** value to `SessionTransportStatus` plus a unit test in `feedback.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c769f78b39cd90721638c9f720d842f1ef2a6e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->