### PR TITLE
fix(web): hide redundant Back to Wrapper header actions

### DIFF
--- a/apps/web/components/auth-shell.tsx
+++ b/apps/web/components/auth-shell.tsx
@@ -7,7 +7,7 @@ export function AuthShell({
   description,
   children,
   size = "compact",
-  showHeaderAction = true,
+  showHeaderAction = false,
   showFooter = true,
 }: {
   title?: string;

--- a/apps/web/components/legal-page.tsx
+++ b/apps/web/components/legal-page.tsx
@@ -12,7 +12,7 @@ interface LegalPageProps {
 export function LegalPage({ title, lastUpdated, introduction, children }: LegalPageProps) {
   return (
     <div className="legalShell">
-      <SiteHeader />
+      <SiteHeader showAction={false} />
       <main id="main-content" className="legalMain" tabIndex={-1}>
         <div className="legalTitle">
           <h1>{title}</h1>


### PR DESCRIPTION
## Summary
- Remove the default **Back to Wrapper** header action from the authorize-a-device screen (`AuthShell` now hides it unless a page opts in).
- Hide the same redundant header action on legal/support pages; the brand mark already links home.
- Leave the 404 page body CTA as the recovery path back to the homepage.

## Test plan
- [ ] Open `/oauth/authorize` and confirm the header has no Back to Wrapper button.
- [ ] Open `/privacy-policy`, `/terms-of-service`, and `/support` and confirm the header has no Back to Wrapper button.
- [ ] Open a missing route and confirm the 404 still offers Back to Wrapper as a page recovery action.
- [ ] Confirm dashboard/onboarding/plan headers are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only header visibility changes with no auth, API, or data impact.
> 
> **Overview**
> **Auth flows and legal pages** no longer show the redundant **Back to Wrapper** control in the site header by default.
> 
> `AuthShell` now defaults `showHeaderAction` to **false**, so pages like `/oauth/authorize` hide the header action unless they pass `showHeaderAction={true}`. **Legal/support layouts** pass `showAction={false}` on `SiteHeader` directly, since the brand link already goes home.
> 
> Dashboard, onboarding, and plan routes that already opted out are unchanged; the 404 page body CTA remains the intended recovery path for missing routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35c670bf75b9b5b23a1c10d8f1ee068b45978d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->