### PR TITLE
fix(web): hide redundant Back to Wrapper header actions

### DIFF
--- a/apps/web/components/auth-shell.tsx
+++ b/apps/web/components/auth-shell.tsx
@@ -7,7 +7,7 @@ export function AuthShell({
   description,
   children,
   size = "compact",
-  showHeaderAction = true,
+  showHeaderAction = false,
   showFooter = true,
 }: {
   title?: string;

--- a/apps/web/components/legal-page.tsx
+++ b/apps/web/components/legal-page.tsx
@@ -12,7 +12,7 @@ interface LegalPageProps {
 export function LegalPage({ title, lastUpdated, introduction, children }: LegalPageProps) {
   return (
     <div className="legalShell">
-      <SiteHeader />
+      <SiteHeader showAction={false} />
       <main id="main-content" className="legalMain" tabIndex={-1}>
         <div className="legalTitle">
           <h1>{title}</h1>


### PR DESCRIPTION
## Summary
- Remove the default **Back to Wrapper** header action from the authorize-a-device screen (`AuthShell` now hides it unless a page opts in).
- Hide the same redundant header action on legal/support pages; the brand mark already links home.
- Leave the 404 page body CTA as the recovery path back to the homepage.
- Merged to `dev` in #73.

## Test plan
- [ ] Open `/oauth/authorize` and confirm the header has no Back to Wrapper button.
- [ ] Open `/privacy-policy`, `/terms-of-service`, and `/support` and confirm the header has no Back to Wrapper button.
- [ ] Open a missing route and confirm the 404 still offers Back to Wrapper as a page recovery action.
- [ ] Quality gate and Full lane green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only header defaults with no auth, API, or data-handling changes.
> 
> **Overview**
> **Auth and legal headers no longer show the default “Back to Wrapper” action**, since the logo already navigates home.
> 
> `AuthShell` now defaults `showHeaderAction` to **false**, so flows like device authorization hide the header CTA unless a page passes `showHeaderAction={true}`. **Legal/support layouts** pass `showAction={false}` on `SiteHeader` explicitly for the same behavior on privacy, terms, and support pages.
> 
> Recovery on **404** is unchanged: the in-page CTA remains the way users get back to the homepage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9c4a396e477c9521547e6eab9c900fc4ff2c72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->