### PR TITLE
fix(web): keep danger delete button red in dark mode

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2679,9 +2679,9 @@ a {
 }
 
 @media (prefers-color-scheme: dark) {
-  .social-btn:not(.social-btn-primary):not(.githubSignInButton):not(.googleSignInButton):not(
-      .appleSignInButton
-    ) {
+  .social-btn:not(.social-btn-primary):not(.social-btn-danger):not(.githubSignInButton):not(
+      .googleSignInButton
+    ):not(.appleSignInButton) {
     background: #1c1c20;
     color: var(--color-text);
   }
@@ -2726,7 +2726,12 @@ a {
 
 @media (prefers-color-scheme: dark) {
   .social-btn-danger {
+    background: #1c1c20;
     color: #ff9393;
+  }
+
+  .social-btn-danger:hover {
+    background: rgba(191, 48, 48, 0.18);
   }
 }
 


### PR DESCRIPTION
## Summary
- Dark-mode generic `social-btn` styles no longer override the filled danger delete button.
- Dashboard **Delete profile and data** stays red in dark mode, matching light mode.
- Ghost danger actions (e.g. Deny) keep a dark surface with red text.

## Test plan
- [ ] Open `/dashboard/data` in dark mode and confirm **Delete profile and data** is a filled red button with white text.
- [ ] Confirm the same button is still filled red in light mode.
- [ ] Open `/oauth/authorize` in dark mode and confirm **Deny** is not a filled red button (ghost/danger text).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only dark-mode selector and appearance tweaks for social buttons; no logic or data-handling changes.
> 
> **Overview**
> Fixes **dark-mode styling** for `social-btn` variants so danger actions look correct instead of inheriting the generic gray pill treatment.
> 
> The catch-all dark rule for secondary `social-btn` elements now **excludes** `.social-btn-danger`, so filled destructive controls (e.g. dashboard **Delete profile and data** via `.dangerAction` / panel rules) are no longer forced to `#1c1c20` and can stay **filled red** like light mode.
> 
> Ghost danger buttons get **explicit dark-mode rules**: dark surface, lighter red label (`#ff9393`), and a slightly stronger red tint on hover—intended for text-style actions such as **Deny** without a solid red fill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f688c9bfbd9870b894a20fec3bf63699fa7b04d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->