### PR TITLE
fix(web): keep danger delete button red in dark mode

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2679,9 +2679,9 @@ a {
 }
 
 @media (prefers-color-scheme: dark) {
-  .social-btn:not(.social-btn-primary):not(.githubSignInButton):not(.googleSignInButton):not(
-      .appleSignInButton
-    ) {
+  .social-btn:not(.social-btn-primary):not(.social-btn-danger):not(.githubSignInButton):not(
+      .googleSignInButton
+    ):not(.appleSignInButton) {
     background: #1c1c20;
     color: var(--color-text);
   }
@@ -2726,7 +2726,12 @@ a {
 
 @media (prefers-color-scheme: dark) {
   .social-btn-danger {
+    background: #1c1c20;
     color: #ff9393;
+  }
+
+  .social-btn-danger:hover {
+    background: rgba(191, 48, 48, 0.18);
   }
 }
 


### PR DESCRIPTION
## Summary
- Dark-mode generic `social-btn` styles no longer override the filled danger delete button.
- Dashboard **Delete profile and data** stays red in dark mode, matching light mode.
- Ghost danger actions (e.g. Deny) keep a dark surface with red text.
- Merged to `dev` in #77.

## Test plan
- [ ] Open `/dashboard/data` in dark mode and confirm **Delete profile and data** is a filled red button with white text.
- [ ] Confirm the same button is still filled red in light mode.
- [ ] Open `/oauth/authorize` in dark mode and confirm **Deny** is not a filled red button (ghost/danger text).
- [ ] Quality gate and Full lane green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only dark-mode selector and danger-button presentation tweaks with no auth or data-path changes.
> 
> **Overview**
> **Dark-mode `social-btn` styling** no longer treats `.social-btn-danger` like a generic secondary pill, so filled destructive actions are not forced onto the `#1c1c20` surface.
> 
> The catch-all dark rule now excludes `.social-btn-danger` (alongside primary and provider sign-in buttons). Ghost danger controls get explicit dark styles: dark surface, lighter red text (`#ff9393`), and a slightly stronger red-tint hover. **Delete profile and data** keeps its filled red look via existing `.dangerAction` / dashboard panel rules; light-mode ghost danger behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af8439ed87ed041c6674b16e872c1af98732a25a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->