### PR TITLE
fix(web): keep pinned plan tooltip interactive

### DIFF
--- a/apps/web/app/surfaces.css
+++ b/apps/web/app/surfaces.css
@@ -868,6 +868,10 @@
   transition-delay: 0s;
 }
 
+.dashboardPlanInfo[data-pinned] .dashboardPlanTooltip {
+  pointer-events: auto;
+}
+
 .dashboardPlanFoot .iosViewerCtaWrap {
   display: inline-flex;
 }


### PR DESCRIPTION
Fix Bugbot finding: re-enable pointer events on pinned plan tooltip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS override for the pinned billing tooltip; no auth, data, or API impact.
> 
> **Overview**
> When users pin the billing plan **“What’s included”** tooltip, it stays visible but was still using the default `pointer-events: none` from `.dashboardPlanTooltip`.
> 
> This adds a pinned-only override (`.dashboardPlanInfo[data-pinned] .dashboardPlanTooltip { pointer-events: auto; }`) so clicks and other pointer input on the open tooltip register on the tooltip instead of passing through to the page—avoiding accidental dismissals and making the pinned state behave like a real interactive popover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a7e3ecf62865cfd5e551a94e58849d0c8c27029. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->