### PR TITLE
fix(web): use icanvardar as hero demo shell username

### DIFF
--- a/apps/web/components/hero-demo/demo-session.ts
+++ b/apps/web/components/hero-demo/demo-session.ts
@@ -18,6 +18,8 @@ export const DEMO_SESSION_TAG = DEMO_SESSION_ID.slice(0, 6);
 export const DEMO_SHARE_CODE = "7N4K-WQ2M";
 export const DEMO_PORT = 51823;
 export const DEMO_HOME = "~/projects/api";
+export const DEMO_USER = "icanvardar";
+export const DEMO_HOME_DIR = `/Users/${DEMO_USER}`;
 export const DEMO_SHELL = "zsh";
 export const PREFIX_LABEL = "Ctrl+\\";
 
@@ -647,7 +649,7 @@ function runCommand(state: DemoState, rawCommand: string): DemoState {
     case "pwd":
       return pushLine(next, "output", expandHome(next.cwd));
     case "whoami":
-      return pushLine(next, "output", "ali");
+      return pushLine(next, "output", DEMO_USER);
     case "uptime":
       return pushLine(
         next,
@@ -679,7 +681,7 @@ function runCommand(state: DemoState, rawCommand: string): DemoState {
       return pushLine(
         next,
         "error",
-        "ali is not in the sudoers file. This incident will be reported.",
+        `${DEMO_USER} is not in the sudoers file. This incident will be reported.`,
       );
     case "rm":
       return pushLine(next, "muted", "nice try — this is a demo shell");
@@ -717,7 +719,7 @@ function runLs(state: DemoState, args: readonly string[]): DemoState {
       const dir = TREE[`${path}/${entry}`] !== undefined || !entry.includes(".");
       const mode = dir ? "drwxr-xr-x" : "-rw-r--r--";
       const size = dir ? "160" : String(400 + entry.length * 37);
-      return `${mode}  1 ali  staff  ${size.padStart(5)} Jun 10 09:41 ${entry}`;
+      return `${mode}  1 ${DEMO_USER}  staff  ${size.padStart(5)} Jun 10 09:41 ${entry}`;
     });
     return pushLines(state, "output", rows);
   }
@@ -840,11 +842,11 @@ function runWrapper(state: DemoState, args: readonly string[]): DemoState {
 // ────────────────────────────────────────────────────────────────────────────
 
 function expandHome(path: string): string {
-  return path.replace(/^~/, "/Users/ali");
+  return path.replace(/^~/, DEMO_HOME_DIR);
 }
 
 function resolvePath(cwd: string, target: string): string {
-  const normalized = target.replace(/^\/Users\/ali(?=\/|$)/, "~");
+  const normalized = target.replace(new RegExp(`^${DEMO_HOME_DIR}(?=\\/|$)`), "~");
   if (normalized.startsWith("/")) return normalized;
   const fromHome = normalized.startsWith("~");
   const stack = fromHome ? ["~"] : cwd.split("/");

--- a/apps/web/components/hero-demo/phone-app.tsx
+++ b/apps/web/components/hero-demo/phone-app.tsx
@@ -7,6 +7,7 @@ import {
   DEMO_SESSION_TAG,
   DEMO_SHARE_CODE,
   DEMO_SHELL,
+  DEMO_HOME_DIR,
   type DemoState,
   type ViewerLink,
   viewerCanConnect,
@@ -44,7 +45,7 @@ import {
 import { TerminalLines, useStickToBottom, useTerminalInput } from "./terminal-view";
 import type { DemoSend } from "./use-demo-session";
 
-const SESSION_CWD = "/Users/ali/projects/api";
+const SESSION_CWD = `${DEMO_HOME_DIR}/projects/api`;
 
 /**
  * The viewer, screen for screen: `SessionNavigationView` (list, summary card,

--- a/apps/web/tests/hero-demo.test.ts
+++ b/apps/web/tests/hero-demo.test.ts
@@ -6,6 +6,7 @@ import {
   DEMO_SESSION_ID,
   DEMO_SESSION_TAG,
   DEMO_SHARE_CODE,
+  DEMO_HOME_DIR,
   type DemoAction,
   type DemoState,
   guideStep,
@@ -58,7 +59,7 @@ describe("hero demo shell", () => {
   test("runs commands, keeps history and echoes the prompt cwd", () => {
     let state = reduceAll(createDemoState(), [...type("cd src"), enter, ...type("pwd"), enter]);
     assert.equal(state.cwd, "~/projects/api/src");
-    assert.equal(lastLine(state)?.text, "/Users/ali/projects/api/src");
+    assert.equal(lastLine(state)?.text, `${DEMO_HOME_DIR}/projects/api/src`);
 
     state = reduceDemo(state, { type: "key", key: "ArrowUp" });
     assert.equal(state.input, "pwd");


### PR DESCRIPTION
## Summary
- Replace hardcoded demo username `ali` with `icanvardar`
- Add shared `DEMO_USER` and `DEMO_HOME_DIR` constants for paths and shell output

## Test plan
- [x] `bun test tests/hero-demo.test.ts`
- [ ] Verify `whoami` and `pwd` in landing hero demo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only presentation and test updates with no production auth, API, or data-path changes.
> 
> **Overview**
> Centralizes the landing **hero demo** identity by introducing shared `DEMO_USER` (`icanvardar`) and `DEMO_HOME_DIR`, replacing scattered hardcoded `ali` / `/Users/ali` values.
> 
> Shell simulation output (`whoami`, `sudo`, `ls -l`), path helpers (`expandHome`, `resolvePath`), the phone viewer’s session CWD label, and the `pwd` unit test assertion now all derive from those constants so Mac and phone stay in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6675fdaa8e664dae27dea6ed0f30c234ed537fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->