### PR TITLE
Merge dev: hero demo username icanvardar

### DIFF
--- a/apps/web/components/hero-demo/demo-session.ts
+++ b/apps/web/components/hero-demo/demo-session.ts
@@ -18,6 +18,8 @@ export const DEMO_SESSION_TAG = DEMO_SESSION_ID.slice(0, 6);
 export const DEMO_SHARE_CODE = "7N4K-WQ2M";
 export const DEMO_PORT = 51823;
 export const DEMO_HOME = "~/projects/api";
+export const DEMO_USER = "icanvardar";
+export const DEMO_HOME_DIR = `/Users/${DEMO_USER}`;
 export const DEMO_SHELL = "zsh";
 export const PREFIX_LABEL = "Ctrl+\\";
 
@@ -647,7 +649,7 @@ function runCommand(state: DemoState, rawCommand: string): DemoState {
     case "pwd":
       return pushLine(next, "output", expandHome(next.cwd));
     case "whoami":
-      return pushLine(next, "output", "ali");
+      return pushLine(next, "output", DEMO_USER);
     case "uptime":
       return pushLine(
         next,
@@ -679,7 +681,7 @@ function runCommand(state: DemoState, rawCommand: string): DemoState {
       return pushLine(
         next,
         "error",
-        "ali is not in the sudoers file. This incident will be reported.",
+        `${DEMO_USER} is not in the sudoers file. This incident will be reported.`,
       );
     case "rm":
       return pushLine(next, "muted", "nice try — this is a demo shell");
@@ -717,7 +719,7 @@ function runLs(state: DemoState, args: readonly string[]): DemoState {
       const dir = TREE[`${path}/${entry}`] !== undefined || !entry.includes(".");
       const mode = dir ? "drwxr-xr-x" : "-rw-r--r--";
       const size = dir ? "160" : String(400 + entry.length * 37);
-      return `${mode}  1 ali  staff  ${size.padStart(5)} Jun 10 09:41 ${entry}`;
+      return `${mode}  1 ${DEMO_USER}  staff  ${size.padStart(5)} Jun 10 09:41 ${entry}`;
     });
     return pushLines(state, "output", rows);
   }
@@ -840,11 +842,11 @@ function runWrapper(state: DemoState, args: readonly string[]): DemoState {
 // ────────────────────────────────────────────────────────────────────────────
 
 function expandHome(path: string): string {
-  return path.replace(/^~/, "/Users/ali");
+  return path.replace(/^~/, DEMO_HOME_DIR);
 }
 
 function resolvePath(cwd: string, target: string): string {
-  const normalized = target.replace(/^\/Users\/ali(?=\/|$)/, "~");
+  const normalized = target.replace(new RegExp(`^${DEMO_HOME_DIR}(?=\\/|$)`), "~");
   if (normalized.startsWith("/")) return normalized;
   const fromHome = normalized.startsWith("~");
   const stack = fromHome ? ["~"] : cwd.split("/");

--- a/apps/web/components/hero-demo/phone-app.tsx
+++ b/apps/web/components/hero-demo/phone-app.tsx
@@ -7,6 +7,7 @@ import {
   DEMO_SESSION_TAG,
   DEMO_SHARE_CODE,
   DEMO_SHELL,
+  DEMO_HOME_DIR,
   type DemoState,
   type ViewerLink,
   viewerCanConnect,
@@ -44,7 +45,7 @@ import {
 import { TerminalLines, useStickToBottom, useTerminalInput } from "./terminal-view";
 import type { DemoSend } from "./use-demo-session";
 
-const SESSION_CWD = "/Users/ali/projects/api";
+const SESSION_CWD = `${DEMO_HOME_DIR}/projects/api`;
 
 /**
  * The viewer, screen for screen: `SessionNavigationView` (list, summary card,

--- a/apps/web/tests/hero-demo.test.ts
+++ b/apps/web/tests/hero-demo.test.ts
@@ -6,6 +6,7 @@ import {
   DEMO_SESSION_ID,
   DEMO_SESSION_TAG,
   DEMO_SHARE_CODE,
+  DEMO_HOME_DIR,
   type DemoAction,
   type DemoState,
   guideStep,
@@ -58,7 +59,7 @@ describe("hero demo shell", () => {
   test("runs commands, keeps history and echoes the prompt cwd", () => {
     let state = reduceAll(createDemoState(), [...type("cd src"), enter, ...type("pwd"), enter]);
     assert.equal(state.cwd, "~/projects/api/src");
-    assert.equal(lastLine(state)?.text, "/Users/ali/projects/api/src");
+    assert.equal(lastLine(state)?.text, `${DEMO_HOME_DIR}/projects/api/src`);
 
     state = reduceDemo(state, { type: "key", key: "ArrowUp" });
     assert.equal(state.input, "pwd");


### PR DESCRIPTION
## Summary
- Use `icanvardar` as the hero demo shell username instead of hardcoded `ali`

## Test plan
- [x] CI passed on PR #83
- [ ] Verify hero demo `whoami` on landing page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only display and test constants; no production auth, API, or data handling changes.
> 
> **Overview**
> Centralizes the landing-page hero demo identity in **`DEMO_USER`** (`icanvardar`) and **`DEMO_HOME_DIR`** (`/Users/icanvardar`), replacing scattered hardcoded `ali` / `/Users/ali` values.
> 
> The fake shell now reports that user for **`whoami`**, **`sudo`**, and **`ls -l`**, and **`expandHome`** / **`resolvePath`** use the shared home path. The phone viewer session row CWD is built from **`DEMO_HOME_DIR`** so Mac and iPhone stay aligned. Hero demo tests assert expanded paths via **`DEMO_HOME_DIR`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79efc5b360cfe10b5662290773fde42d61fc05e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->