### PR TITLE
Merge dev: type scale and centered hero layout

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -54,6 +54,18 @@
   --radius-md: 24px;
   --radius-lg: 32px;
   --radius-pill: 999px;
+  /* Type scale. 12px is the floor for anything a person has to read, and only
+     badges and eyebrow labels sit there; running text starts at 14px and the
+     copy a page is about lands at 16px. Line heights pair with the size:
+     tight for headings, 1.5 and up for anything that wraps (WCAG 1.4.12). */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --leading-tight: 1.2;
+  --leading-snug: 1.35;
+  --leading-body: 1.55;
   --page-pad: clamp(20px, 5.5vw, 80px);
   --content-max: 1280px;
   --header-h: 72px;

--- a/apps/web/app/hero-demo.css
+++ b/apps/web/app/hero-demo.css
@@ -5,14 +5,17 @@
 
 /* ── Stage ─────────────────────────────────────────────────────────────── */
 
-/* --mw is the MacBook's full width. The lid's left edge bleeds off the
-   viewport by --bleed (shallow enough that the Apple menu stays on screen) and
-   the base rests on the bottom of the stage. The phone stands in front of the
-   Mac's lower-right corner. */
+/* --mw is the MacBook's full width. The Mac and the phone are laid out as one
+   block --pair times that wide (the phone overhangs the Mac's right edge), and
+   the block is centred in the stage: whatever room the column has beyond the
+   pair splits evenly to both sides instead of piling up between the Mac and
+   the copy, and the whole lid stays on screen rather than being clipped at
+   the bezel. The phone stands in front of the Mac's lower-right corner. */
 .demoStage {
-  --mw: min(100cqw, 126cqh);
-  --bleed: calc(var(--mw) * 0.05);
+  --pair: 1.065;
+  --mw: min(100cqw / var(--pair), 126cqh);
   --pw: calc(var(--mw) * 0.29);
+  --pair-x: calc((100cqw - var(--mw) * var(--pair)) / 2);
   /* The Mac hangs from the top of the stage; the phone is offset from the same
      anchor so the pair moves together. */
   --mac-top: 8cqh;
@@ -33,7 +36,7 @@
 .demoStage .macbook {
   top: var(--mac-top);
   bottom: auto;
-  left: calc(-1 * var(--bleed));
+  left: var(--pair-x);
   z-index: 1;
   width: var(--mw);
   margin: 0;
@@ -206,7 +209,7 @@
   top: calc(var(--mac-top) + var(--mw) * 0.035);
   right: auto;
   bottom: auto;
-  left: calc(var(--mw) * 0.775 - var(--bleed));
+  left: calc(var(--pair-x) + var(--mw) * 0.775);
   z-index: 4;
   width: var(--pw);
   margin: 0;
@@ -1929,6 +1932,8 @@
 /* ── Compact stage (stacked layout) ────────────────────────────────────── */
 
 @media (max-width: 1023px), (prefers-reduced-motion: reduce) {
+  /* Stacked, the Mac is wider than the stage and bleeds a little off both
+     sides, so the pair is pinned to the left rather than centred. */
   .demoStage {
     --mw: 108cqw;
     --bleed: calc(var(--mw) * 0.06);
@@ -1939,6 +1944,7 @@
   .demoStage .macbook {
     top: auto;
     bottom: calc(var(--mw) * 0.03);
+    left: calc(-1 * var(--bleed));
   }
 
   .demoStage .iphone {
@@ -1957,13 +1963,13 @@
 @media (max-width: 760px) {
   .demoStage {
     --mw: 100cqw;
-    --bleed: 0cqw;
     --pw: 60cqw;
   }
 
   .demoStage .macbook {
     top: 0;
     bottom: auto;
+    left: 0;
   }
 
   .demoStage .iphone {

--- a/apps/web/app/landing.css
+++ b/apps/web/app/landing.css
@@ -180,12 +180,14 @@ html.lenis body {
   padding-bottom: 0;
 }
 
-/* The hero is the one section allowed past --content-max: the MacBook bleeds
-   off the left edge of the viewport and the copy keeps a readable column on
-   the right. --hero-bleed is the distance from the inner box to that edge. */
+/* The hero is the one section allowed past --content-max: the devices take
+   the wide column on the left and the copy keeps a readable column on the
+   right. The media column starts at the page padding like everything else, so
+   the MacBook's left edge lands on the same line as the header's logo (or sits
+   inside it when the column has room to spare) rather than hanging just off
+   the viewport edge. */
 .landingHeroInner {
   --hero-max: 1680px;
-  --hero-bleed: max(var(--page-pad), (100vw - var(--hero-max)) / 2);
   display: grid;
   grid-template-columns: minmax(0, 1fr) clamp(320px, 27vw, 460px);
   gap: clamp(24px, 3.5vw, 64px);
@@ -206,7 +208,6 @@ html.lenis body {
   align-self: stretch;
   min-width: 0;
   min-height: 560px;
-  margin-left: calc(-1 * var(--hero-bleed));
 }
 
 .connectionSteps {

--- a/apps/web/app/surfaces.css
+++ b/apps/web/app/surfaces.css
@@ -174,7 +174,7 @@
   padding: 0 12px;
   border-radius: var(--radius-sm);
   color: var(--color-text-muted);
-  font-size: 0.8125rem;
+  font-size: var(--text-sm);
   font-weight: 510;
   transition:
     background-color var(--motion-fast) ease,
@@ -224,10 +224,10 @@
 }
 
 .dashboardPageHeader p {
-  max-width: 520px;
+  max-width: 60ch;
   color: var(--color-text-muted);
-  font-size: 0.9375rem;
-  line-height: 1.5;
+  font-size: var(--text-md);
+  line-height: var(--leading-body);
 }
 
 .dashboardPageActions {
@@ -281,23 +281,23 @@
   display: block;
   margin-bottom: 4px;
   color: var(--color-text-muted);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-weight: 590;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
 .dashboardPanel h2 {
-  font-size: 1rem;
+  font-size: var(--text-lg);
   font-weight: 590;
-  line-height: 1.25;
+  line-height: var(--leading-tight);
   letter-spacing: -0.03em;
 }
 
 .dashboardPanelCopy {
   color: var(--color-text-muted);
-  font-size: 0.8125rem;
-  line-height: 1.6;
+  font-size: var(--text-sm);
+  line-height: var(--leading-body);
 }
 
 .dashboardPanelCopy code {
@@ -315,7 +315,8 @@
   gap: 16px;
   padding: 11px 0;
   border-bottom: 1px solid var(--color-border);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
 }
 
 .dashboardDetails > div:last-child {
@@ -346,6 +347,17 @@
 .dashboardDeleteConfirmation {
   display: grid;
   gap: 12px;
+}
+
+/* Form feedback inside the dashboard reads at running-text size: an error
+   under "Sign out" or "Permanently delete" is not fine print. The native
+   dialog stays in this subtree, so the confirmation form is covered too. */
+.dashboardWorkspace .authLabel,
+.dashboardWorkspace .authInfo,
+.dashboardWorkspace .authSuccess,
+.dashboardWorkspace .authError {
+  font-size: var(--text-sm);
+  line-height: var(--leading-body);
 }
 
 /* Confirmation dialog (native <dialog>). The element itself is the backdrop
@@ -386,16 +398,19 @@
 
 .confirmDialogPanel h2 {
   margin: 0;
-  font-size: 1.15rem;
+  font-size: var(--text-xl);
   font-weight: 600;
+  line-height: var(--leading-tight);
   letter-spacing: -0.02em;
 }
 
+/* What is about to happen is the one line in the dialog everyone must read,
+   so it sits at body size rather than a step below. */
 .confirmDialogBody {
   margin: 0;
   color: var(--color-text-muted);
-  font-size: 0.9rem;
-  line-height: 1.5;
+  font-size: var(--text-md);
+  line-height: var(--leading-body);
 }
 
 .confirmDialogActions {
@@ -450,8 +465,9 @@
 
 .dashboardActionPanel h2,
 .dashboardDangerPanel h2 {
-  font-size: 1rem;
+  font-size: var(--text-lg);
   font-weight: 590;
+  line-height: var(--leading-tight);
   letter-spacing: -0.03em;
 }
 
@@ -459,8 +475,8 @@
 .dashboardDangerPanel p,
 .dashboardNotice p {
   color: var(--color-text-muted);
-  font-size: 0.78rem;
-  line-height: 1.55;
+  font-size: var(--text-sm);
+  line-height: var(--leading-body);
 }
 
 .dashboardSessionCards {
@@ -487,12 +503,14 @@
   background: currentColor;
 }
 
+/* Mono runs wider than the sans, so it drops a notch from the surrounding
+   text (13px against 14px) and still clears the 12px floor. */
 .dashboardSessionCard code,
 .dashboardNotice code {
   overflow: hidden;
   color: var(--color-text-muted);
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: 0.9375em;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -531,8 +549,8 @@
   background: var(--color-text);
   color: var(--color-bg);
   font-family: var(--font-mono);
-  font-size: 0.75rem;
-  line-height: 1.45;
+  font-size: 0.8125rem;
+  line-height: var(--leading-body);
   overflow-wrap: anywhere;
   opacity: 0;
   pointer-events: none;
@@ -565,7 +583,7 @@
   border-radius: var(--radius-pill);
   background: var(--color-surface);
   color: var(--color-text-muted);
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   font-weight: 590;
 }
 
@@ -592,8 +610,9 @@
 }
 
 .dashboardSessionCard h2 {
-  font-size: 1rem;
+  font-size: var(--text-lg);
   font-weight: 590;
+  line-height: var(--leading-tight);
 }
 
 .dashboardSessionCard dl {
@@ -606,7 +625,8 @@
   gap: 16px;
   padding: 10px 0;
   border-bottom: 1px solid var(--color-border);
-  font-size: 0.75rem;
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
 }
 
 .dashboardSessionCard dl > div:last-child {
@@ -650,12 +670,13 @@
   border-radius: var(--radius-md);
   background: var(--color-surface-strong);
   color: var(--color-text-muted);
-  font-size: 0.8125rem;
-  line-height: 1.5;
+  font-size: var(--text-sm);
+  line-height: var(--leading-body);
 }
 
 .dashboardEmptyState strong {
   color: var(--color-text);
+  font-size: var(--text-md);
   font-weight: 590;
 }
 
@@ -675,7 +696,7 @@
 }
 
 .dashboardNotice strong {
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   font-weight: 590;
 }
 
@@ -731,12 +752,11 @@
 
 .dashboardPlanName .dashboardPanelLabel {
   margin-bottom: 0;
-  font-size: 0.6875rem;
 }
 
 .dashboardPlanName h2 {
-  font-size: 1.125rem;
-  line-height: 1.2;
+  font-size: var(--text-lg);
+  line-height: var(--leading-tight);
   letter-spacing: -0.03em;
 }
 
@@ -750,13 +770,13 @@
 }
 
 .dashboardPlanCard .dashboardPlanPrice span {
-  font-size: 0.8125rem;
+  font-size: var(--text-sm);
 }
 
 .dashboardPriceLead {
   color: var(--color-text-muted);
-  font-size: 0.875rem;
-  line-height: 1.45;
+  font-size: var(--text-sm);
+  line-height: var(--leading-body);
   letter-spacing: -0.015em;
 }
 
@@ -786,7 +806,7 @@
   background: transparent;
   color: var(--color-text-muted);
   font: inherit;
-  font-size: 0.8125rem;
+  font-size: var(--text-sm);
   font-weight: 510;
   letter-spacing: -0.01em;
   transition:
@@ -825,8 +845,8 @@
   border-radius: 10px;
   background: var(--color-text);
   color: var(--color-bg);
-  font-size: 0.8125rem;
-  line-height: 1.45;
+  font-size: var(--text-sm);
+  line-height: var(--leading-body);
   letter-spacing: -0.01em;
   box-shadow: 0 12px 32px -12px rgba(0, 0, 0, 0.35);
   opacity: 0;
@@ -878,7 +898,7 @@
 
 .dashboardPlanFoot .iosViewerCtaText {
   min-height: 24px;
-  font-size: 0.8125rem;
+  font-size: var(--text-sm);
 }
 
 .dashboardProPanel {
@@ -1018,7 +1038,7 @@
 
 .dashboardPlanPrice span {
   color: var(--color-text-muted);
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
   font-weight: 500;
   letter-spacing: -0.02em;
 }
@@ -1029,8 +1049,8 @@
   margin: 0;
   padding: 0;
   color: var(--color-text-muted);
-  font-size: 0.78rem;
-  line-height: 1.45;
+  font-size: var(--text-sm);
+  line-height: var(--leading-body);
   list-style: none;
 }
 


### PR DESCRIPTION
## Summary
- Shared type scale CSS variables applied across dashboard
- Hero demo Mac/phone pair centered in stage
- Convex generated file sync

## Test plan
- [x] CI passed on PR #85

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only typography and layout adjustments with no application logic or data-handling changes.
> 
> **Overview**
> Introduces a **shared type scale** in `globals.css` (`--text-*` and `--leading-*`) and wires **dashboard and confirmation UI** in `surfaces.css` to those tokens instead of one-off `rem` sizes. Copy in dialogs and form feedback is bumped where needed (e.g. confirm body at body size, dashboard auth messages at `--text-sm`), with mono snippets sized relative to surrounding text.
> 
> **Landing hero layout** changes so the device column no longer bleeds off the left viewport: `landing.css` drops `--hero-bleed` and the negative margin on hero media, and `hero-demo.css` centers the Mac/phone pair in the stage on desktop (`--pair`, `--pair-x`) while keeping the existing left-bleed behavior for stacked breakpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5d9c8cc42880bd1c3594821f2812aed0b27c568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->