### PR TITLE
Merge dev: touch-aware hero demo and autoplay

### DIFF
--- a/apps/web/app/hero-demo.css
+++ b/apps/web/app/hero-demo.css
@@ -586,13 +586,16 @@
 }
 
 /* A frosted pill under the handwriting keeps it legible over the busiest
-   parts of the wallpaper without turning the note into a UI card. */
+   parts of the wallpaper without turning the note into a UI card. The tint
+   is set for the light wallpaper, whose pale sky and warm corner sit right
+   under the note (white on them needs about half-strength navy to clear
+   4.5:1); the dark wallpaper below eases it off. */
 .demoNote {
   max-width: 60cqw;
   margin: 0;
   padding: 0.35cqw 1cqw 0.45cqw;
   border-radius: 1.4cqw;
-  background: rgba(8, 20, 48, 0.28);
+  background: rgba(8, 20, 48, 0.55);
   color: #fff;
   font-family: var(--font-hand), "Bradley Hand", "Segoe Print", cursive;
   font-size: 2.45cqw;
@@ -627,8 +630,10 @@
   scale: -1 -1;
 }
 
+/* Waiting notes step back a little; in colour, not opacity, so the tint
+   behind them keeps doing its job. */
 .demoNote.isQuiet {
-  opacity: 0.82;
+  color: rgba(255, 255, 255, 0.86);
 }
 
 .demoNoteArrow {
@@ -1931,59 +1936,94 @@
 
 /* ── Compact stage (stacked layout) ────────────────────────────────────── */
 
+/* Stacked under the copy, the pair keeps the desktop composition and its
+   centring, but with no column of text beside it the phone can take a larger
+   share of the Mac's width (the pair grows to match) and the terminal's type
+   steps up, so both stay legible on a tablet held upright. The stage is sized
+   by the hero media's aspect ratio (landing.css), so the Mac hangs from the
+   top and the phone's bottom edge lands just inside it. */
 @media (max-width: 1023px), (prefers-reduced-motion: reduce) {
-  /* Stacked, the Mac is wider than the stage and bleeds a little off both
-     sides, so the pair is pinned to the left rather than centred. */
   .demoStage {
-    --mw: 108cqw;
-    --bleed: calc(var(--mw) * 0.06);
-    --pw: calc(var(--mw) * 0.3);
+    --pair: 1.135;
+    --pw: calc(var(--mw) * 0.36);
+    --mac-top: 0px;
   }
 
-  /* Stacked, the stage is sized to its contents, so anchor to the bottom. */
-  .demoStage .macbook {
-    top: auto;
-    bottom: calc(var(--mw) * 0.03);
-    left: calc(-1 * var(--bleed));
-  }
-
-  .demoStage .iphone {
-    top: auto;
-    right: 0.5cqw;
-    bottom: 0;
-    left: auto;
+  .demoMacWindow .macContent {
+    font-size: 1.9cqw;
   }
 }
 
-/* Phones: side by side the pair would be thumbnails, so the scene stacks.
-   The Mac takes the full width with the terminal filling its display, and
-   the phone sits below at two thirds of the width, large enough for its own
-   controls to be tapped. The hero media's aspect ratio (landing.css) is what
-   gives the stage the height for both. */
+/* Phones: anything MacBook-shaped at this width has a display 170px tall,
+   which fits neither the terminal nor the note. So the scene flips to match
+   the visitor, who is holding a phone: the MacBook is reduced to its display
+   (bezel, notch and rounded corners, no chassis), drawn taller than 16:10 so
+   the terminal shows seven lines above the note, and the iPhone becomes the
+   main object, most of the width and cropped to its upper part, fading out
+   below the join button. The two overlap by a sliver so they read as one
+   scene. The hero media's aspect ratio (landing.css) is what gives the stage
+   the height for both. */
 @media (max-width: 760px) {
   .demoStage {
     --mw: 100cqw;
-    --pw: 60cqw;
+    --pw: 86cqw;
   }
 
+  /* Nearly square: seven lines of terminal, then a two-line note with its
+     pill button, all above where the phone overlaps the panel. */
   .demoStage .macbook {
     top: 0;
     bottom: auto;
     left: 0;
+    aspect-ratio: 1 / 0.96;
+  }
+
+  .demoStage .macbookLid {
+    inset: 0;
+    border-radius: 3.4cqw;
+  }
+
+  .demoStage .macbookScreen {
+    inset: 1.1cqw;
+    border-radius: 2.4cqw;
+  }
+
+  .demoStage .macbookNotch {
+    top: 1.1cqw;
+  }
+
+  .demoStage .macbookBase {
+    display: none;
   }
 
   .demoStage .iphone {
     top: auto;
-    right: auto;
+    right: 0;
     bottom: 0;
-    left: 20cqw;
+    left: auto;
+    aspect-ratio: 402 / 600;
+    /* The lower part of the phone fades out rather than being cut; the mask
+       also clips the shell's overhang and the drop shadow, so the shadow goes. */
+    filter: none;
+    mask-image: linear-gradient(to bottom, #000 80%, transparent 97%);
+  }
+
+  /* The shell reaches past the mask by more than its corner radius, so the
+     crop shows a phone that continues: no bottom edge, no corner starting to
+     curve inside the fade. The ring, bezel and screen are 100% tall and
+     follow; what they push lower (home indicator, key bar) is under the mask. */
+  .demoStage .iphoneShell {
+    bottom: -20cqw;
   }
 
   .demoStage .macWindow {
-    top: 9%;
+    top: 7%;
     left: 4%;
     width: 92%;
-    height: 62%;
+    height: 58%;
+    /* The window's corners scale with the screen; at this size the desktop
+       ratio gives 5px, too tight for 14px type. */
+    border-radius: 2.6cqw;
   }
 
   /* At phone widths the Dock would compete with the note for the strip under
@@ -1992,13 +2032,21 @@
     display: none;
   }
 
+  /* Menu titles keep the desktop widths, so the height only goes up enough
+     to stay visible at 3px: taller and they turn from dashes into blobs next
+     to the notch. The Apple mark, a 4px smudge at the desktop ratio, grows. */
   .macMenuPill,
   .macMenuDot {
-    height: 1.4cqw;
+    height: 0.95cqw;
   }
 
   .macMenuDot {
-    width: 1.4cqw;
+    width: 0.95cqw;
+  }
+
+  .macMenuIcon {
+    width: 2cqw;
+    height: 2cqw;
   }
 
   /* The Mac is now the width of a phone screen, so everything inside it is
@@ -2043,7 +2091,7 @@
   }
 
   .demoGuide {
-    top: 73%;
+    top: 67%;
     right: 4%;
     left: 4%;
   }
@@ -2053,6 +2101,24 @@
     padding: 1cqw 2.6cqw 1.2cqw;
     border-radius: 3cqw;
     font-size: 4.2cqw;
+  }
+
+  /* The phone is below the panel here, not beside it, so the arrows that
+     point at it turn to point down-right. */
+  .demoNoteArrow.isTrailing {
+    scale: -1 -1;
+    vertical-align: -0.15em;
+    animation-name: demoArrowNudgeDown;
+  }
+
+  @keyframes demoArrowNudgeDown {
+    0%,
+    100% {
+      translate: 0 0;
+    }
+    45% {
+      translate: 0.1em 0.08em;
+    }
   }
 
   /* Pressed keys echo in the title bar's free right half rather than under
@@ -2068,6 +2134,70 @@
     height: 8cqw;
     min-width: 8cqw;
     font-size: 4cqw;
+  }
+}
+
+/* ── Touch input ───────────────────────────────────────────────────────── */
+
+/* The guide's notes carry a keyboard phrasing and a touch phrasing; one of
+   them shows. The query is the complement of the scripts' `(hover: hover) and
+   (pointer: fine)` (use-coarse-pointer.ts), written out so it also holds
+   before hydration and in browsers without `not (…)` media queries. */
+.demoWhenTouch {
+  display: none;
+}
+
+@media (hover: none), (pointer: coarse), (pointer: none) {
+  .demoWhenKeys {
+    display: none;
+  }
+
+  .demoWhenTouch {
+    display: inline;
+  }
+
+  /* Without a keyboard the shell is display only (product-demo.tsx drops the
+     hidden input, the drag grip and the keycaps): the window stops advertising
+     affordances it no longer has, and the title bar gives the page its scroll
+     back. */
+  .demoMacWindow .macTitlebar {
+    cursor: default;
+    touch-action: auto;
+  }
+
+  .demoMacWindow .macContent {
+    cursor: default;
+  }
+
+  /* The button is the one way through the loop here, so it stops being an
+     underlined word in the handwriting and becomes a pill: a 40px target in
+     the page's sans, on its own line under the note's sentence. */
+  .demoNoteAction {
+    display: flex;
+    width: fit-content;
+    min-height: 40px;
+    align-items: center;
+    padding: 0 16px;
+    margin: 0.4em 0 0.1em;
+    border-radius: 999px;
+    background: #fff;
+    color: #10254d;
+    font-family: var(--font-sans);
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1;
+    letter-spacing: -0.01em;
+    text-decoration: none;
+    box-shadow: 0 0.15cqw 0.6cqw rgba(0, 20, 60, 0.35);
+    transition: scale var(--motion-fast) ease;
+  }
+
+  .demoNoteAction:active {
+    scale: 0.97;
+  }
+
+  .demoNoteAction:focus-visible {
+    outline-offset: 2px;
   }
 }
 
@@ -2224,6 +2354,10 @@
     outline-color: #7aa7ff;
   }
 
+  .demoNote {
+    background: rgba(8, 20, 48, 0.34);
+  }
+
   /* Keycaps read as dark keys on a dark keyboard. */
   .demoKeys kbd,
   .demoKeycap {
@@ -2262,10 +2396,6 @@
   .demoKeycap {
     opacity: 1;
     transform: none;
-  }
-
-  .demoNote.isQuiet {
-    opacity: 0.82;
   }
 }
 

--- a/apps/web/app/landing.css
+++ b/apps/web/app/landing.css
@@ -1359,13 +1359,16 @@ html.lenis body {
     order: -1;
   }
 
+  /* Stacked scene (hero-demo.css): the pair is centred in the column, so the
+     media box stays on the page grid. Its height is the phone's, which at 36%
+     of the Mac's width hangs to 0.78 of it; the ratio leaves a little over. */
   .landingHeroMedia {
     align-self: auto;
-    width: calc(100% + var(--page-pad));
+    width: 100%;
     height: auto;
     min-height: 0;
-    margin: 0 0 0 calc(-1 * var(--page-pad));
-    aspect-ratio: 100 / 68;
+    margin: 0;
+    aspect-ratio: 100 / 70;
   }
 
   .landingConnectionVisual {
@@ -1439,12 +1442,13 @@ html.lenis body {
     min-height: 48px;
   }
 
-  /* Stacked scene (hero-demo.css): the Mac's height plus the phone's, less
-     the sliver where the phone overlaps the Mac's base. */
+  /* Phone scene (hero-demo.css): the Mac display panel (0.96 of the width)
+     plus the cropped phone (0.86 wide at 402:600, so 1.284 tall), less the
+     sliver where the phone overlaps the panel's bottom edge (~0.054). */
   .landingHeroMedia {
     width: 100%;
     margin-left: 0;
-    aspect-ratio: 100 / 178;
+    aspect-ratio: 100 / 219;
   }
 
   .landingSplit,

--- a/apps/web/components/hero-demo/demo-guide.tsx
+++ b/apps/web/components/hero-demo/demo-guide.tsx
@@ -1,15 +1,22 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { type DemoState, type GuideStep, guideStep } from "./demo-session";
 import type { DemoSend, Keycap } from "./use-demo-session";
 
 /**
  * Handwritten margin notes that nudge the visitor through the loop. Each
- * note is also the fallback for people who cannot type the prefix (touch
- * screens, keyboard layouts where `\` needs AltGr): clicking it performs the
- * same action the keys would, and the keycap trail still shows the keys. The
- * container is a polite live region so each new note is read out as the loop
- * advances, not only seen.
+ * note is also the fallback for people who cannot type the prefix (keyboard
+ * layouts where `\` needs AltGr): clicking it performs the same action the
+ * keys would, and the keycap trail still shows the keys.
+ *
+ * Every note carries two phrasings. With a keyboard it names the chord and
+ * offers the button as a shortcut; on touch there are no keys to press, so the
+ * chord goes and the button, drawn as a pill, becomes the one way through.
+ * Which phrasing shows is decided by CSS (`.demoWhenKeys` / `.demoWhenTouch`
+ * in hero-demo.css) on the same pointer query the scripts use, so the note is
+ * right from the first paint rather than after hydration. The container is a
+ * polite live region so each new note is read out as the loop advances.
  */
 export function DemoGuide({ state, send }: { state: DemoState; send: DemoSend }) {
   const step = guideStep(state);
@@ -26,14 +33,15 @@ function Note({ step, send }: { step: GuideStep; send: DemoSend }) {
       return (
         <p className="demoNote">
           <HandArrow />
-          share this session: press <Keys caps={"⌃ \\"} /> then <Keys caps="s" /> or{" "}
-          <button
-            type="button"
-            className="demoNoteAction"
+          <Keyboard>
+            share this session: press <Keys caps={"⌃ \\"} /> then <Keys caps="s" /> or{" "}
+          </Keyboard>
+          <Touch>nothing leaves the Mac until you share it </Touch>
+          <Action
             onClick={() => send({ type: "hostCommand", command: "share" })}
-          >
-            share for me
-          </button>
+            keyboard="share for me"
+            touch="Share this session"
+          />
         </p>
       );
     case "sharing":
@@ -46,15 +54,20 @@ function Note({ step, send }: { step: GuideStep; send: DemoSend }) {
     case "tap":
       return (
         <p className="demoNote">
-          it just showed up on the phone — tap the session{" "}
-          <button
-            type="button"
-            className="demoNoteAction"
+          <Keyboard>it just showed up on the phone — tap the session </Keyboard>
+          {/* On touch the pill takes its own line, so the arrow at the phone
+              closes the sentence instead of trailing the button. */}
+          <Touch>
+            it just showed up on the phone — tap the session, or <HandArrow trailing />
+          </Touch>
+          <Action
             onClick={() => send({ type: "tapSession" })}
-          >
-            or tap it for me
-          </button>
-          <HandArrow trailing />
+            keyboard="or tap it for me"
+            touch="Open it for me"
+          />
+          <Keyboard>
+            <HandArrow trailing />
+          </Keyboard>
         </p>
       );
     case "connecting":
@@ -68,35 +81,71 @@ function Note({ step, send }: { step: GuideStep; send: DemoSend }) {
       return (
         <p className="demoNote">
           <HandArrow />
-          keep typing — it&apos;s live on both.{" "}
-          <span className="demoNoteChord">
-            <Keys caps={"⌃ \\ u"} />{" "}
-            <button
-              type="button"
-              className="demoNoteAction"
-              onClick={() => send({ type: "hostCommand", command: "unshare" })}
-            >
-              closes the share
-            </button>
-          </span>
+          <Keyboard>
+            keep typing — it&apos;s live on both.{" "}
+            <span className="demoNoteChord">
+              <Keys caps={"⌃ \\ u"} />{" "}
+            </span>
+          </Keyboard>
+          <Touch>it&apos;s live on both — the same shell, keystroke for keystroke. </Touch>
+          <Action
+            onClick={() => send({ type: "hostCommand", command: "unshare" })}
+            keyboard="closes the share"
+            touch="Close the share"
+          />
         </p>
       );
     case "done":
       return (
         <p className="demoNote">
           that&apos;s the whole loop — nothing left the Mac until you said so.{" "}
-          <button type="button" className="demoNoteAction" onClick={() => send({ type: "reset" })}>
-            start over ↺
-          </button>
+          <Action
+            onClick={() => send({ type: "reset" })}
+            keyboard="start over ↺"
+            touch="Start over ↺"
+          />
         </p>
       );
   }
 }
 
+/** Shown only when a keyboard and a fine pointer are at hand. */
+function Keyboard({ children }: { children: ReactNode }) {
+  return <span className="demoWhenKeys">{children}</span>;
+}
+
+/** Shown only on touch. */
+function Touch({ children }: { children: ReactNode }) {
+  return <span className="demoWhenTouch">{children}</span>;
+}
+
+/**
+ * The note's one control. A single button so there is one tab stop; the two
+ * labels inside it are toggled by the same CSS as the surrounding text, so a
+ * screen reader only ever meets the one that is showing.
+ */
+function Action({
+  onClick,
+  keyboard,
+  touch,
+}: {
+  onClick: () => void;
+  keyboard: string;
+  touch: string;
+}) {
+  return (
+    <button type="button" className="demoNoteAction" onClick={onClick}>
+      <Keyboard>{keyboard}</Keyboard>
+      <Touch>{touch}</Touch>
+    </button>
+  );
+}
+
 /**
  * A sketched arrow, drawn with a slightly bowed shaft and an open head so it
  * matches the handwritten notes. Leading arrows point up-left at the window;
- * trailing ones are mirrored to point up-right at the phone.
+ * trailing ones are mirrored to point up-right at the phone (and turned to
+ * point down-right where the phone sits below the panel, see hero-demo.css).
  */
 function HandArrow({ trailing = false }: { trailing?: boolean }) {
   return (

--- a/apps/web/components/hero-demo/mac-terminal.tsx
+++ b/apps/web/components/hero-demo/mac-terminal.tsx
@@ -8,16 +8,25 @@ import type { useWindowDrag } from "./use-window-drag";
 
 type Drag = ReturnType<typeof useWindowDrag>;
 
+/**
+ * The terminal window on the Mac. With a keyboard and a fine pointer it is a
+ * live shell: tapping focuses it, the title bar drags it. On touch the loop is
+ * driven from the guide's buttons instead, so the window is display only: no
+ * hidden input to summon a soft keyboard over the page, no drag grip to fight
+ * the page's scroll, and no caret promising input.
+ */
 export function MacTerminal({
   state,
   send,
   windowRef,
   drag,
+  touch = false,
 }: {
   state: DemoState;
   send: DemoSend;
   windowRef: RefObject<HTMLElement | null>;
   drag: Drag;
+  touch?: boolean;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const { focus, inputProps } = useTerminalInput("mac", send);
@@ -31,16 +40,20 @@ export function MacTerminal({
       aria-label="Host terminal"
       data-transport={hostTransport(state)}
       data-armed={state.armed ? "true" : "false"}
-      onPointerDown={(event) => {
-        // Let real text selection happen inside the scrollback; anything else
-        // focuses the shell so the next keystroke lands in it.
-        if (event.button !== 0) return;
-        if (window.getSelection()?.toString()) return;
-        event.preventDefault();
-        focus();
-      }}
+      onPointerDown={
+        touch
+          ? undefined
+          : (event) => {
+              // Let real text selection happen inside the scrollback; anything
+              // else focuses the shell so the next keystroke lands in it.
+              if (event.button !== 0) return;
+              if (window.getSelection()?.toString()) return;
+              event.preventDefault();
+              focus();
+            }
+      }
     >
-      <header className="macTitlebar" {...drag.handleProps}>
+      <header className="macTitlebar" {...(touch ? {} : drag.handleProps)}>
         <span className="macTraffic" aria-hidden="true">
           <i />
           <i />
@@ -49,28 +62,36 @@ export function MacTerminal({
         <h3 className={state.armed ? "isArmed" : ""}>{hostTitle(state)}</h3>
       </header>
       <div className="macContent demoScrollback" ref={scrollRef}>
-        <TerminalLines lines={state.lines} input={state.input} cwd={state.cwd} focused={focused} />
-        <input {...inputProps} />
+        <TerminalLines
+          lines={state.lines}
+          input={state.input}
+          cwd={state.cwd}
+          focused={focused}
+          showCaret={!touch}
+        />
+        {touch ? null : <input {...inputProps} />}
       </div>
       {/* Drawn in the title bar, but placed after the shell in the DOM so Tab
           reaches the terminal first and window-moving second. */}
-      <button
-        type="button"
-        className="macMoveHandle"
-        aria-label="Move the terminal window. Use the arrow keys; Home puts it back."
-        {...drag.keyboardProps}
-      >
-        <svg viewBox="0 0 16 16" aria-hidden="true">
-          <path
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M8 1.5v13M1.5 8h13M8 1.5 5.8 3.7M8 1.5l2.2 2.2M8 14.5l-2.2-2.2M8 14.5l2.2-2.2M1.5 8l2.2-2.2M1.5 8l2.2 2.2M14.5 8l-2.2-2.2M14.5 8l-2.2 2.2"
-          />
-        </svg>
-      </button>
+      {touch ? null : (
+        <button
+          type="button"
+          className="macMoveHandle"
+          aria-label="Move the terminal window. Use the arrow keys; Home puts it back."
+          {...drag.keyboardProps}
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M8 1.5v13M1.5 8h13M8 1.5 5.8 3.7M8 1.5l2.2 2.2M8 14.5l-2.2-2.2M8 14.5l2.2-2.2M1.5 8l2.2-2.2M1.5 8l2.2 2.2M14.5 8l-2.2-2.2M14.5 8l-2.2 2.2"
+            />
+          </svg>
+        </button>
+      )}
     </section>
   );
 }

--- a/apps/web/components/hero-demo/phone-app.tsx
+++ b/apps/web/components/hero-demo/phone-app.tsx
@@ -54,7 +54,16 @@ const SESSION_CWD = `${DEMO_HOME_DIR}/projects/api`;
  * on the stack. Sheets present the way iOS does: the list shrinks into a card
  * on black while the system status bar stays put above everything.
  */
-export function PhoneApp({ state, send }: { state: DemoState; send: DemoSend }) {
+export function PhoneApp({
+  state,
+  send,
+  touch = false,
+}: {
+  state: DemoState;
+  send: DemoSend;
+  /** No keyboard at hand: the terminal is display only (see MacTerminal). */
+  touch?: boolean;
+}) {
   const { screen } = state.viewer;
   const isDetail = screen === "terminal";
   const hasSheet = screen === "join" || screen === "settings";
@@ -70,7 +79,7 @@ export function PhoneApp({ state, send }: { state: DemoState; send: DemoSend }) 
         {overlay ? <PreparationOverlay state={state} send={send} /> : null}
       </div>
       <div className="iosPage iosDetailPage" inert={!isDetail}>
-        <TerminalScreen state={state} send={send} active={isDetail} />
+        <TerminalScreen state={state} send={send} active={isDetail} touch={touch} />
       </div>
       <div className="iosSheetDim" aria-hidden="true" />
       <div
@@ -490,10 +499,12 @@ function TerminalScreen({
   state,
   send,
   active,
+  touch,
 }: {
   state: DemoState;
   send: DemoSend;
   active: boolean;
+  touch: boolean;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [ctrlArmed, setCtrlArmed] = useState(false);
@@ -552,15 +563,25 @@ function TerminalScreen({
       <div
         className="iosTerminalBody demoScrollback"
         ref={scrollRef}
-        onPointerDown={(event) => {
-          if (event.button !== 0) return;
-          if (window.getSelection()?.toString()) return;
-          event.preventDefault();
-          focus();
-        }}
+        onPointerDown={
+          touch
+            ? undefined
+            : (event) => {
+                if (event.button !== 0) return;
+                if (window.getSelection()?.toString()) return;
+                event.preventDefault();
+                focus();
+              }
+        }
       >
-        <TerminalLines lines={state.lines} input={state.input} cwd={state.cwd} focused={focused} />
-        <input {...inputProps} />
+        <TerminalLines
+          lines={state.lines}
+          input={state.input}
+          cwd={state.cwd}
+          focused={focused}
+          showCaret={!touch}
+        />
+        {touch ? null : <input {...inputProps} />}
         {link === "connecting" ? (
           <div className="iosStage">
             <Spinner className="isLarge" />
@@ -579,8 +600,13 @@ function TerminalScreen({
         <KeyCap icon={ArrowUp} label="Up arrow" onPress={() => sendKey("ArrowUp")} />
         <KeyCap icon={ArrowRight} label="Right arrow" onPress={focus} />
         <KeyCap icon={Ellipsis} label="Terminal symbols" onPress={focus} />
-        <i className="iosKeySeparator" aria-hidden="true" />
-        <KeyCap icon={Keyboard} label="Show keyboard" onPress={focus} />
+        {/* The keyboard key would open nothing where there is no input. */}
+        {touch ? null : (
+          <>
+            <i className="iosKeySeparator" aria-hidden="true" />
+            <KeyCap icon={Keyboard} label="Show keyboard" onPress={focus} />
+          </>
+        )}
       </div>
       <i className="iosHomeIndicator" aria-hidden="true" />
     </div>

--- a/apps/web/components/hero-demo/use-coarse-pointer.ts
+++ b/apps/web/components/hero-demo/use-coarse-pointer.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * The hero's input surfaces (typing into the shell, dragging the window) are
+ * only offered where a real keyboard and a fine pointer are at hand. Anything
+ * else counts as touch: a phone, a tablet without a trackpad, a kiosk. Layout
+ * is decided separately by width; a keyboard-equipped iPad gets the compact
+ * layout but keeps typing, a touch-only desktop-sized screen does not.
+ */
+const FINE_POINTER = "(hover: hover) and (pointer: fine)";
+
+function subscribe(onChange: () => void): () => void {
+  const query = window.matchMedia(FINE_POINTER);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+const getSnapshot = () => !window.matchMedia(FINE_POINTER).matches;
+// Server render and the hydration pass assume a fine pointer, so the markup
+// matches; a touch device switches on the first client render.
+const getServerSnapshot = () => false;
+
+export function useCoarsePointer(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/apps/web/components/hero-demo/use-demo-autoplay.ts
+++ b/apps/web/components/hero-demo/use-demo-autoplay.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { type DemoState, guideStep } from "./demo-session";
+import type { DemoSend } from "./use-demo-session";
+
+/** How much of the stage has to be on screen before the loop starts. */
+const VISIBLE_RATIO = 0.5;
+/** Pauses that read as a person deciding, not a script firing. */
+const BEFORE_SHARE_MS = 1800;
+const BEFORE_TAP_MS = 1600;
+const BEFORE_TYPING_MS = 900;
+const KEYSTROKE_MS = 120;
+const BEFORE_UNSHARE_MS = 3200;
+/** What the phone "types" once it is attached. */
+const TYPED_COMMAND = "ls";
+
+type Phase = "waiting" | "playing" | "stopped";
+
+/**
+ * Walks the demo once on its own where nobody is going to type: on touch, most
+ * visitors scroll past a demo that waits for a tap, and would never see that
+ * the phone attaches or that a keystroke lands on both screens. The run starts
+ * when the stage is mostly in view, follows the same steps the guide asks
+ * for, and stops for good the moment the visitor does anything themselves or
+ * scrolls the stage away. Off when motion is reduced, and off with a keyboard,
+ * where the notes invite the visitor to drive.
+ */
+export function useDemoAutoplay(
+  stageRef: RefObject<HTMLElement | null>,
+  state: DemoState,
+  send: DemoSend,
+  enabled: boolean,
+) {
+  const [phase, setPhase] = useState<Phase>("waiting");
+  const stop = useCallback(() => setPhase("stopped"), []);
+
+  // Start when the stage scrolls into view; give up if it scrolls away again.
+  useEffect(() => {
+    if (!enabled || phase === "stopped") return;
+    const stage = stageRef.current;
+    if (!stage || typeof IntersectionObserver === "undefined") return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry) return;
+        if (entry.intersectionRatio >= VISIBLE_RATIO) setPhase("playing");
+        else setPhase((current) => (current === "playing" ? "stopped" : current));
+      },
+      { threshold: [VISIBLE_RATIO] },
+    );
+    observer.observe(stage);
+    return () => observer.disconnect();
+  }, [enabled, phase, stageRef]);
+
+  // Drive the loop step by step. Each step schedules only its own next move,
+  // so the state machine's own latencies (relay, ticket, P2P) still pace it.
+  const step = guideStep(state);
+  const sendRef = useRef(send);
+  sendRef.current = send;
+  useEffect(() => {
+    if (!enabled || phase !== "playing") return;
+    const timers: number[] = [];
+    const after = (delay: number, run: () => void) => {
+      timers.push(window.setTimeout(run, delay));
+    };
+    switch (step) {
+      case "share":
+        after(BEFORE_SHARE_MS, () => sendRef.current({ type: "hostCommand", command: "share" }));
+        break;
+      case "tap":
+        after(BEFORE_TAP_MS, () => sendRef.current({ type: "tapSession" }));
+        break;
+      case "live": {
+        let at = BEFORE_TYPING_MS;
+        for (const key of TYPED_COMMAND) {
+          after(at, () => sendRef.current({ type: "key", key }));
+          at += KEYSTROKE_MS;
+        }
+        after(at, () => sendRef.current({ type: "key", key: "Enter" }));
+        after(at + BEFORE_UNSHARE_MS, () =>
+          sendRef.current({ type: "hostCommand", command: "unshare" }),
+        );
+        break;
+      }
+      case "done":
+        setPhase("stopped");
+        break;
+      case "sharing":
+      case "connecting":
+        break;
+    }
+    return () => timers.forEach((timer) => window.clearTimeout(timer));
+  }, [enabled, phase, step]);
+
+  /** Call from anything the visitor does; the script yields to them. */
+  return { stop } as const;
+}

--- a/apps/web/components/product-demo.tsx
+++ b/apps/web/components/product-demo.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useRef } from "react";
+import { useCallback, useRef } from "react";
 import { DemoGuide, KeycapTrail } from "./hero-demo/demo-guide";
 import { MacDock, MacMenuBar } from "./hero-demo/mac-desktop";
-import { guideStep, hostTransport } from "./hero-demo/demo-session";
+import { type DemoAction, guideStep, hostTransport } from "./hero-demo/demo-session";
 import { MacTerminal } from "./hero-demo/mac-terminal";
 import { PhoneApp } from "./hero-demo/phone-app";
 import { useWrapperAnnouncements } from "./hero-demo/terminal-view";
+import { useCoarsePointer } from "./hero-demo/use-coarse-pointer";
+import { useDemoAutoplay } from "./hero-demo/use-demo-autoplay";
 import { useDemoSession } from "./hero-demo/use-demo-session";
 import { useWindowDrag } from "./hero-demo/use-window-drag";
 
@@ -16,22 +18,39 @@ import { useWindowDrag } from "./hero-demo/use-window-drag";
  * machine (`hero-demo/demo-session.ts`), so what the visitor types on the Mac
  * is what the phone shows, and sharing from the shell is what makes the
  * session appear in the app.
+ *
+ * With a keyboard the visitor types the loop. On touch the shell is display
+ * only: the loop plays itself once when the stage comes into view, and the
+ * guide's buttons and the phone let the visitor take over at any point.
  */
 export function ProductDemo() {
   const { state, send, keycaps } = useDemoSession();
   const liveRef = useWrapperAnnouncements(state);
+  const stageRef = useRef<HTMLElement>(null);
   const windowRef = useRef<HTMLElement>(null);
+  const touch = useCoarsePointer();
   // The window's drag offset lives on the screen so the guide notes and the
   // keycap trail, which annotate the window, move with it.
   const drag = useWindowDrag(windowRef);
+  const { stop } = useDemoAutoplay(stageRef, state, send, touch);
+  // Anything the visitor does ends the scripted run before it is applied.
+  const sendFromVisitor = useCallback(
+    (action: DemoAction) => {
+      stop();
+      send(action);
+    },
+    [send, stop],
+  );
 
   return (
     <figure
+      ref={stageRef}
       className="productStage demoStage"
       aria-label="Interactive demo: Wrapper on a MacBook and the iOS viewer"
       data-demo-step={guideStep(state)}
       data-demo-transport={hostTransport(state)}
       data-demo-viewer={state.viewer.screen}
+      data-demo-input={touch ? "touch" : "keyboard"}
       data-live=""
     >
       <div className="macbook">
@@ -43,9 +62,15 @@ export function ProductDemo() {
           >
             <div className="macWallpaper" aria-hidden="true" />
             <MacMenuBar />
-            <MacTerminal state={state} send={send} windowRef={windowRef} drag={drag} />
-            <DemoGuide state={state} send={send} />
-            <KeycapTrail keycaps={keycaps} />
+            <MacTerminal
+              state={state}
+              send={sendFromVisitor}
+              windowRef={windowRef}
+              drag={drag}
+              touch={touch}
+            />
+            <DemoGuide state={state} send={sendFromVisitor} />
+            {touch ? null : <KeycapTrail keycaps={keycaps} />}
             <MacDock />
           </div>
           <div className="macbookNotch" aria-hidden="true">
@@ -64,7 +89,7 @@ export function ProductDemo() {
           <div className="iphoneRing">
             <div className="iphoneBezel">
               <div className="iphoneScreen">
-                <PhoneApp state={state} send={send} />
+                <PhoneApp state={state} send={sendFromVisitor} touch={touch} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Touch-specific hero demo guide copy and coarse pointer detection
- Autoplay share loop on touch devices when stage is in view

## Test plan
- [x] CI passed on PR #89 (dev)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/landing UI and demo interaction only; no auth, APIs, or data handling changes.
> 
> **Overview**
> Makes the landing **hero product demo** work on touch/coarse pointers without pretending visitors can type into the Mac shell, while tightening **responsive layout** and **note legibility**.
> 
> **Touch vs keyboard:** Adds `useCoarsePointer` (fine pointer = `(hover: hover) and (pointer: fine)`) and CSS toggles `.demoWhenKeys` / `.demoWhenTouch` so guide copy and a single `Action` button show the right label before hydration. On touch, `MacTerminal` and the phone terminal become display-only (no hidden input, drag handle, caret, or “show keyboard” key); guide actions render as **40px pill buttons**. `KeycapTrail` is hidden on touch.
> 
> **Autoplay on touch:** `useDemoAutoplay` runs the share → tap → type `ls` → unshare loop once when ~50% of the stage is visible; it stops on visitor interaction (`sendFromVisitor`), scroll-away, or reduced motion. Keyboard users still drive the loop manually.
> 
> **Layout/CSS:** Tablet stack recenters the device pair and bumps phone/terminal scale; at ≤760px the Mac becomes a **display panel** (no base), the iPhone is larger with a bottom fade mask, dock hides, and trailing arrows nudge down toward the phone. `landingHeroMedia` aspect ratios update to match. Guide note tint is stronger in light mode (contrast) with a lighter dark-mode variant; quiet notes dim via text color, not opacity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c8b6be7cbe047e3aa80f1e19fb05fcb09042ce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->